### PR TITLE
Add product inventory and retrieval API

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -138,6 +138,29 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ message: "Failed to delete category" });
     }
   });
+
+  // Products route
+  app.get("/api/products", async (req, res) => {
+    try {
+      const category = req.query.category as string;
+      const search = req.query.search as string;
+
+      let items = category
+        ? await storage.getProductsByCategory(category)
+        : await storage.getProducts();
+
+      if (search) {
+        items = items.filter(product =>
+          product.name.toLowerCase().includes(search.toLowerCase()) ||
+          product.description?.toLowerCase().includes(search.toLowerCase())
+        );
+      }
+
+      res.json(items);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch products" });
+    }
+  });
   // Clothing Items routes
   app.get("/api/clothing-items", async (req, res) => {
     try {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -19,6 +19,16 @@ export const laundryServices = pgTable("laundry_services", {
   category: text("category").notNull(),
 });
 
+export const products = pgTable("products", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  description: text("description"),
+  category: text("category"),
+  price: decimal("price", { precision: 10, scale: 2 }).notNull(),
+  stock: integer("stock").notNull().default(0),
+  imageUrl: text("image_url"),
+});
+
 export const transactions = pgTable("transactions", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   items: jsonb("items").notNull(),
@@ -123,6 +133,10 @@ export const insertLaundryServiceSchema = createInsertSchema(laundryServices).om
   id: true,
 });
 
+export const insertProductSchema = createInsertSchema(products).omit({
+  id: true,
+});
+
 export const insertCustomerSchema = createInsertSchema(customers).omit({
   id: true,
   createdAt: true,
@@ -165,6 +179,8 @@ export type ClothingItem = typeof clothingItems.$inferSelect;
 export type InsertClothingItem = z.infer<typeof insertClothingItemSchema>;
 export type LaundryService = typeof laundryServices.$inferSelect;
 export type InsertLaundryService = z.infer<typeof insertLaundryServiceSchema>;
+export type Product = typeof products.$inferSelect;
+export type InsertProduct = z.infer<typeof insertProductSchema>;
 export type Transaction = typeof transactions.$inferSelect;
 export type InsertTransaction = z.infer<typeof insertTransactionSchema>;
 export type Category = typeof categories.$inferSelect;


### PR DESCRIPTION
## Summary
- define `products` table and related types in shared schema
- expand storage layer with product CRUD and seed data
- expose `/api/products` route with category and search filters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npx tsx test-products.ts` *(returns [ 'Potato Chips' ])*


------
https://chatgpt.com/codex/tasks/task_e_688fb755a0b88323b201bcc537d84cbc