### PR TITLE
Add security settings management

### DIFF
--- a/client/src/components/security-settings.tsx
+++ b/client/src/components/security-settings.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import type { SecuritySettings as SecuritySettingsType, InsertSecuritySettings } from "@shared/schema";
+import { Shield } from "lucide-react";
+
+export function SecuritySettings() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: settings } = useQuery<SecuritySettingsType>({
+    queryKey: ["/api/security-settings"],
+  });
+
+  const [sessionTimeout, setSessionTimeout] = useState("15");
+  const [twoFactorRequired, setTwoFactorRequired] = useState(false);
+  const [passwordPolicy, setPasswordPolicy] = useState("");
+
+  useEffect(() => {
+    if (settings) {
+      setSessionTimeout(settings.sessionTimeout.toString());
+      setTwoFactorRequired(settings.twoFactorRequired);
+      setPasswordPolicy(settings.passwordPolicy || "");
+    }
+  }, [settings]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (data: InsertSecuritySettings) => {
+      const res = await apiRequest("PUT", "/api/security-settings", data);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/security-settings"] });
+      toast({ title: "Settings saved" });
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "Failed to save security settings",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSave = () => {
+    saveMutation.mutate({
+      sessionTimeout: parseInt(sessionTimeout, 10),
+      twoFactorRequired,
+      passwordPolicy,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <Shield className="h-5 w-5" />
+          <span>Security Settings</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="sessionTimeout">Session Timeout (minutes)</Label>
+          <Input
+            id="sessionTimeout"
+            type="number"
+            value={sessionTimeout}
+            onChange={(e) => setSessionTimeout(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="twoFactorRequired">Require Two-Factor Authentication</Label>
+          </div>
+          <Switch
+            id="twoFactorRequired"
+            checked={twoFactorRequired}
+            onCheckedChange={setTwoFactorRequired}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="passwordPolicy">Password Policy</Label>
+          <Input
+            id="passwordPolicy"
+            value={passwordPolicy}
+            onChange={(e) => setPasswordPolicy(e.target.value)}
+            placeholder="e.g., Minimum 8 characters"
+          />
+        </div>
+        <Button onClick={handleSave} disabled={saveMutation.isPending}>
+          Save Changes
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SecuritySettings;
+

--- a/client/src/components/settings-panel.tsx
+++ b/client/src/components/settings-panel.tsx
@@ -9,6 +9,9 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
+import { cn } from "@/lib/utils";
+import { SecuritySettings } from "./security-settings";
 
 export function SettingsPanel() {
   const [settings, setSettings] = useState({
@@ -41,6 +44,8 @@ export function SettingsPanel() {
   });
 
   const { toast } = useToast();
+  const { isAdmin, isSuperAdmin } = useAuth();
+  const showSecurity = isAdmin || isSuperAdmin;
 
   const handleSettingChange = (key: string, value: string | boolean | number) => {
     setSettings(prev => ({
@@ -106,12 +111,13 @@ export function SettingsPanel() {
         </div>
 
         <Tabs defaultValue="business" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-5">
+          <TabsList className={cn("grid w-full", showSecurity ? "grid-cols-6" : "grid-cols-5")}>
             <TabsTrigger value="business">Business</TabsTrigger>
             <TabsTrigger value="receipts">Receipts</TabsTrigger>
             <TabsTrigger value="system">System</TabsTrigger>
             <TabsTrigger value="pricing">Pricing</TabsTrigger>
             <TabsTrigger value="appearance">Appearance</TabsTrigger>
+            {showSecurity && <TabsTrigger value="security">Security</TabsTrigger>}
           </TabsList>
 
           <TabsContent value="business" className="space-y-6">
@@ -395,6 +401,11 @@ export function SettingsPanel() {
               </CardContent>
             </Card>
           </TabsContent>
+          {showSecurity && (
+            <TabsContent value="security" className="space-y-6">
+              <SecuritySettings />
+            </TabsContent>
+          )}
         </Tabs>
       </div>
     </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema } from "@shared/schema";
+import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema, insertSecuritySettingsSchema } from "@shared/schema";
 import { setupAuth, requireAuth, requireSuperAdmin, requireAdminOrSuperAdmin } from "./auth";
 import passport from "passport";
 import type { User } from "@shared/schema";
@@ -186,6 +186,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error deleting branch:", error);
       res.status(500).json({ message: "Failed to delete branch" });
+    }
+  });
+
+  // Security settings (Admin or Super Admin)
+  app.get("/api/security-settings", requireAdminOrSuperAdmin, async (_req, res) => {
+    try {
+      const settings = await storage.getSecuritySettings();
+      res.json(settings);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch security settings" });
+    }
+  });
+
+  app.put("/api/security-settings", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const validated = insertSecuritySettingsSchema.parse(req.body);
+      const updated = await storage.updateSecuritySettings(validated);
+      res.json(updated);
+    } catch (error) {
+      console.error("Error updating security settings:", error);
+      res.status(400).json({ message: "Invalid security settings data" });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -141,6 +141,15 @@ export const notifications = pgTable("notifications", {
   sentAt: timestamp("sent_at").defaultNow().notNull(),
 });
 
+// Security settings
+export const securitySettings = pgTable("security_settings", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  sessionTimeout: integer("session_timeout").notNull().default(15),
+  twoFactorRequired: boolean("two_factor_required").notNull().default(false),
+  passwordPolicy: text("password_policy"),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
 // Loyalty points history for tracking accrual and redemption
 export const loyaltyHistory = pgTable("loyalty_history", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -183,6 +192,11 @@ export const insertPaymentSchema = createInsertSchema(payments).omit({
 export const insertNotificationSchema = createInsertSchema(notifications).omit({
   id: true,
   sentAt: true,
+});
+
+export const insertSecuritySettingsSchema = createInsertSchema(securitySettings).omit({
+  id: true,
+  updatedAt: true,
 });
 
 export const insertTransactionSchema = createInsertSchema(transactions).omit({
@@ -236,6 +250,8 @@ export type Notification = typeof notifications.$inferSelect;
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;
 export type LoyaltyHistory = typeof loyaltyHistory.$inferSelect;
 export type InsertLoyaltyHistory = z.infer<typeof insertLoyaltyHistorySchema>;
+export type SecuritySettings = typeof securitySettings.$inferSelect;
+export type InsertSecuritySettings = z.infer<typeof insertSecuritySettingsSchema>;
 
 export interface LaundryCartItem {
   id: string;


### PR DESCRIPTION
## Summary
- add security settings UI with session timeout, two-factor toggle, and password policy
- show Security tab in settings for admins and super admins
- persist security settings in new database table with API and storage helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688fe727288c8323b2632d6f652a0718