### PR TITLE
feat: add profile settings

### DIFF
--- a/client/src/components/profile-settings.tsx
+++ b/client/src/components/profile-settings.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
+import { apiRequest } from "@/lib/queryClient";
+import { useQueryClient } from "@tanstack/react-query";
+import { User as UserIcon } from "lucide-react";
+
+export function ProfileSettings() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState(user?.firstName || "");
+  const [email, setEmail] = useState(user?.email || "");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    try {
+      await apiRequest("PUT", `/api/users/${user.id}`, {
+        firstName: name,
+        email,
+      });
+      if (password) {
+        await apiRequest("PUT", `/api/users/${user.id}/password`, { password });
+      }
+      await queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
+      toast({ title: "Profile updated" });
+      setPassword("");
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: (err as Error).message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <UserIcon className="h-5 w-5" />
+          <span>Profile</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">New Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <Button type="submit">Save Changes</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ProfileSettings;
+

--- a/client/src/components/settings-panel.tsx
+++ b/client/src/components/settings-panel.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { cn } from "@/lib/utils";
 import { SecuritySettings } from "./security-settings";
+import { ProfileSettings } from "./profile-settings";
 
 export function SettingsPanel() {
   const [settings, setSettings] = useState({
@@ -111,7 +112,8 @@ export function SettingsPanel() {
         </div>
 
         <Tabs defaultValue="business" className="space-y-6">
-          <TabsList className={cn("grid w-full", showSecurity ? "grid-cols-6" : "grid-cols-5")}>
+          <TabsList className={cn("grid w-full", showSecurity ? "grid-cols-7" : "grid-cols-6")}>
+            <TabsTrigger value="profile">Profile</TabsTrigger>
             <TabsTrigger value="business">Business</TabsTrigger>
             <TabsTrigger value="receipts">Receipts</TabsTrigger>
             <TabsTrigger value="system">System</TabsTrigger>
@@ -119,6 +121,10 @@ export function SettingsPanel() {
             <TabsTrigger value="appearance">Appearance</TabsTrigger>
             {showSecurity && <TabsTrigger value="security">Security</TabsTrigger>}
           </TabsList>
+
+          <TabsContent value="profile" className="space-y-6">
+            <ProfileSettings />
+          </TabsContent>
 
           <TabsContent value="business" className="space-y-6">
             <Card>


### PR DESCRIPTION
## Summary
- add self-service profile settings UI and backend endpoints
- secure user update and password change routes with auth
- support profile update and password hashing in storage layer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688fea5c8e6883239795f5b61d4b3470