### PR TITLE
feat: add reporting endpoints

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -55,6 +55,10 @@ Preferred communication style: Simple, everyday language.
 - **Laundry Services API**: GET /api/laundry-services (with category/search filtering), GET /api/laundry-services/:id
 - **Transactions API**: POST /api/transactions for order processing
 - **Service Management**: No stock tracking needed as laundry services are unlimited capacity
+- **Reports API**:
+  - `GET /api/reports/orders?range=daily|weekly|monthly|yearly` → `{ totalOrders, totalRevenue, stats: [{ period, count, revenue }] }`
+  - `GET /api/reports/top-services?range=daily|weekly|monthly|yearly` → `{ services: [{ service, count, revenue }] }`
+  - `GET /api/reports/top-products?range=daily|weekly|monthly|yearly` → `{ products: [{ product, count, revenue }] }`
 
 ### Cart Management
 - **Local State**: Custom React hook managing laundry cart items (clothing + service combinations)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -713,6 +713,37 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Reports routes
+  app.get("/api/reports/orders", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const range = (req.query.range as string) || "daily";
+      const summary = await storage.getSalesSummary(range);
+      res.json(summary);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch order reports" });
+    }
+  });
+
+  app.get("/api/reports/top-services", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const range = (req.query.range as string) || "daily";
+      const services = await storage.getTopServices(range);
+      res.json({ services });
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch top services" });
+    }
+  });
+
+  app.get("/api/reports/top-products", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const range = (req.query.range as string) || "daily";
+      const products = await storage.getTopProducts(range);
+      res.json({ products });
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch top products" });
+    }
+  });
+
   const httpServer = createServer(app);
   return httpServer;
 }


### PR DESCRIPTION
## Summary
- implement SQL-backed report helpers for order stats, top services, top products and sales summary
- add admin-protected API routes for `/api/reports/orders`, `/api/reports/top-services`, `/api/reports/top-products`
- document report query params and response shapes

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890ad35dc0c8323917a8dff6bcbf966