### PR TITLE
chore: add database url

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://neondb_owner:npg_wfEeVO2TLmM7@ep-calm-sky-a9oyagro-pooler.gwc.azure.neon.tech/neondb?sslmode=require&channel_binding=require

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.1",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4384,6 +4385,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "seed": "tsx server/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -50,6 +51,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+import { db } from './db';
+import { users } from '@shared/schema';
+import bcrypt from 'bcryptjs';
+
+async function main() {
+  const username = process.env.SEED_USERNAME ?? 'admin';
+  const password = process.env.SEED_PASSWORD ?? 'admin123';
+  const passwordHash = await bcrypt.hash(password, 10);
+
+  await db
+    .insert(users)
+    .values({ username, passwordHash, role: 'super_admin' })
+    .onConflictDoNothing({ target: users.username });
+
+  console.log(`Seeded user "${username}" with password "${password}"`);
+}
+
+main().then(() => process.exit(0)).catch((err) => {
+  console.error('Seeding failed', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add DATABASE_URL to `.env`
- add seed script for a default admin user

## Testing
- `npm run db:push` *(fails: connect ENETUNREACH 72.144.105.10:5432 - Local (0.0.0.0:0))*
- `npm run seed` *(fails: connect ENETUNREACH 72.144.105.10:443 - Local (0.0.0.0:0))*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890db2eed5083239760962a9aa5ec37