### PR TITLE
feat: add dynamic tax rate

### DIFF
--- a/client/src/components/cart-sidebar.tsx
+++ b/client/src/components/cart-sidebar.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { CartSummary } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { getTaxRate } from "@/lib/tax";
 
 interface CartSidebarProps {
   cartSummary: CartSummary;
@@ -28,6 +29,7 @@ export function CartSidebar({
   onClose
 }: CartSidebarProps) {
   const isMobile = useIsMobile();
+  const taxRate = getTaxRate();
 
   return (
     <div className={`
@@ -118,10 +120,12 @@ export function CartSidebar({
               <span className="text-gray-600">Subtotal:</span>
               <span className="font-medium">${cartSummary.subtotal.toFixed(2)}</span>
             </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">Tax (8.5%):</span>
-              <span className="font-medium">${cartSummary.tax.toFixed(2)}</span>
-            </div>
+            {taxRate > 0 && (
+              <div className="flex justify-between">
+                <span className="text-gray-600">Tax ({(taxRate * 100).toString()}%):</span>
+                <span className="font-medium">${cartSummary.tax.toFixed(2)}</span>
+              </div>
+            )}
             <div className="flex justify-between text-lg font-bold border-t border-gray-200 pt-3">
               <span>Total:</span>
               <span>${cartSummary.total.toFixed(2)}</span>

--- a/client/src/components/laundry-cart-sidebar.tsx
+++ b/client/src/components/laundry-cart-sidebar.tsx
@@ -14,6 +14,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useCurrency } from "@/lib/currency";
+import { getTaxRate } from "@/lib/tax";
 
 interface LaundryCartSidebarProps {
   cartSummary: LaundryCartSummary;
@@ -46,6 +47,7 @@ export function LaundryCartSidebar({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { formatCurrency } = useCurrency();
+  const taxRate = getTaxRate();
 
   const [isCustomerDialogOpen, setIsCustomerDialogOpen] = useState(false);
   const [customerSearch, setCustomerSearch] = useState("");
@@ -331,10 +333,12 @@ export function LaundryCartSidebar({
               <span className="text-gray-600">Subtotal:</span>
               <span className="font-medium">{formatCurrency(cartSummary.subtotal)}</span>
             </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">Tax (8.5%):</span>
-              <span className="font-medium">{formatCurrency(cartSummary.tax)}</span>
-            </div>
+            {taxRate > 0 && (
+              <div className="flex justify-between">
+                <span className="text-gray-600">Tax ({(taxRate * 100).toString()}%):</span>
+                <span className="font-medium">{formatCurrency(cartSummary.tax)}</span>
+              </div>
+            )}
             {selectedCustomer && maxRedeemable > 0 && (
               <div className="flex items-center justify-between">
                 <span className="text-gray-600">

--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from "react";
 import logoImage from "@/assets/logo.png";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { getTaxRate } from "@/lib/tax";
 
 interface ReceiptModalProps {
   transaction?: Transaction | null;
@@ -22,6 +23,7 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
   const { t } = useTranslation();
   const { formatCurrency } = useCurrency();
   const { toast } = useToast();
+  const taxRate = getTaxRate();
   
   // Get dynamic company settings
   const [companyName, setCompanyName] = useState('');
@@ -239,10 +241,12 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
               <span>{t.subtotal}:</span>
               <span>{formatCurrency(receiptData.subtotal)}</span>
             </div>
-            <div className="flex justify-between">
-              <span>{t.tax}:</span>
-              <span>{formatCurrency(receiptData.tax)}</span>
-            </div>
+            {taxRate > 0 && (
+              <div className="flex justify-between">
+                <span>{t.tax}:</span>
+                <span>{formatCurrency(receiptData.tax)}</span>
+              </div>
+            )}
             <div className="flex justify-between font-bold border-t pt-1">
               <span>{t.total}:</span>
               <span>{formatCurrency(receiptData.total)}</span>

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback } from "react";
 import { CartItem, CartSummary } from "@shared/schema";
-
-const TAX_RATE = 0.085; // 8.5%
+import { getTaxRate } from "@/lib/tax";
 
 export function useCart() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
@@ -55,7 +54,8 @@ export function useCart() {
 
   const getCartSummary = useCallback((): CartSummary => {
     const subtotal = cartItems.reduce((sum, item) => sum + item.total, 0);
-    const tax = subtotal * TAX_RATE;
+    const taxRate = getTaxRate();
+    const tax = subtotal * taxRate;
     const total = subtotal + tax;
     const itemCount = cartItems.reduce((sum, item) => sum + item.quantity, 0);
 

--- a/client/src/hooks/use-laundry-cart.tsx
+++ b/client/src/hooks/use-laundry-cart.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback } from "react";
 import { LaundryCartItem, LaundryCartSummary, ClothingItem, LaundryService } from "@shared/schema";
-
-const TAX_RATE = 0.085; // 8.5%
+import { getTaxRate } from "@/lib/tax";
 
 export function useLaundryCart() {
   const [cartItems, setCartItems] = useState<LaundryCartItem[]>([]);
@@ -61,7 +60,8 @@ export function useLaundryCart() {
 
   const getCartSummary = useCallback((): LaundryCartSummary => {
     const subtotal = cartItems.reduce((sum, item) => sum + item.total, 0);
-    const tax = subtotal * TAX_RATE;
+    const taxRate = getTaxRate();
+    const tax = subtotal * taxRate;
     const total = subtotal + tax;
     const itemCount = cartItems.reduce((sum, item) => sum + item.quantity, 0);
 

--- a/client/src/lib/tax.ts
+++ b/client/src/lib/tax.ts
@@ -1,0 +1,8 @@
+export function getTaxRate(): number {
+  if (typeof window === "undefined") {
+    return 0.085;
+  }
+  const stored = localStorage.getItem("taxRate");
+  const parsed = stored ? parseFloat(stored) : 8.5;
+  return (isNaN(parsed) ? 8.5 : parsed) / 100;
+}


### PR DESCRIPTION
## Summary
- load tax rate from localStorage with fallback default
- compute cart tax dynamically in cart hooks
- show/hide tax in sidebars and receipts based on configured rate

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890f931d5608323b5e2eb1c066a0cfd