### PR TITLE
feat(i18n): add auth translations and localize login form

### DIFF
--- a/client/src/components/auth/LoginForm.tsx
+++ b/client/src/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import logoUrl from "@/assets/logo.png";
+import { useTranslation } from "@/lib/i18n";
 
 interface LoginFormProps {
   onLoginSuccess?: () => void;
@@ -17,6 +18,7 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
   const [password, setPassword] = useState("");
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   const loginMutation = useMutation({
     mutationFn: async (credentials: { username: string; password: string }) => {
@@ -25,8 +27,8 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
     },
     onSuccess: (data) => {
       toast({
-        title: "Login Successful",
-        description: "Welcome to the Laundry Management System",
+        title: t.loginSuccess,
+        description: t.welcome,
       });
       // Force refresh the auth state
       queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
@@ -35,7 +37,7 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
     },
     onError: (error) => {
       toast({
-        title: "Login Failed",
+        title: t.loginFailed,
         description: error.message,
         variant: "destructive",
       });
@@ -46,8 +48,8 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
     e.preventDefault();
     if (!username || !password) {
       toast({
-        title: "Error",
-        description: "Please enter both username and password",
+        title: t.error,
+        description: t.missingCredentials,
         variant: "destructive",
       });
       return;
@@ -62,30 +64,30 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
           <div className="flex justify-center mb-4">
             <img src={logoUrl} alt="Laundry Logo" className="w-16 h-16 object-cover rounded-lg" />
           </div>
-          <CardTitle className="text-2xl">Laundry Management</CardTitle>
-          <CardDescription>Sign in to access the system</CardDescription>
+          <CardTitle className="text-2xl">{t.loginTitle}</CardTitle>
+          <CardDescription>{t.loginDescription}</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="username">Username</Label>
+              <Label htmlFor="username">{t.usernameLabel}</Label>
               <Input
                 id="username"
                 type="text"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
-                placeholder="Enter your username"
+                placeholder={t.usernameLabel}
                 required
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="password">{t.passwordLabel}</Label>
               <Input
                 id="password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="Enter your password"
+                placeholder={t.passwordLabel}
                 required
               />
             </div>
@@ -96,7 +98,7 @@ export function LoginForm({ onLoginSuccess }: LoginFormProps) {
               className="w-full" 
               disabled={loginMutation.isPending}
             >
-              {loginMutation.isPending ? "Signing in..." : "Sign In"}
+              {loginMutation.isPending ? t.signingIn : t.loginButton}
             </Button>
           </CardFooter>
         </form>

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -157,6 +157,17 @@ export interface Translations {
   name: string;
   newPassword: string;
   profileUpdated: string;
+  // Auth
+  loginTitle: string;
+  loginDescription: string;
+  usernameLabel: string;
+  passwordLabel: string;
+  loginButton: string;
+  signingIn: string;
+  loginSuccess: string;
+  welcome: string;
+  loginFailed: string;
+  missingCredentials: string;
 }
 
 const translations: Record<Language, Translations> = {
@@ -314,6 +325,17 @@ const translations: Record<Language, Translations> = {
     name: "Name",
     newPassword: "New Password",
     profileUpdated: "Profile updated",
+    // Auth
+    loginTitle: "Laundry Management",
+    loginDescription: "Sign in to access the system",
+    usernameLabel: "Username",
+    passwordLabel: "Password",
+    loginButton: "Sign In",
+    signingIn: "Signing in...",
+    loginSuccess: "Login Successful",
+    welcome: "Welcome to the Laundry Management System",
+    loginFailed: "Login Failed",
+    missingCredentials: "Please enter both username and password",
   },
   ar: {
     // Common
@@ -469,6 +491,17 @@ const translations: Record<Language, Translations> = {
     name: "الاسم",
     newPassword: "كلمة مرور جديدة",
     profileUpdated: "تم تحديث الملف الشخصي",
+    // Auth
+    loginTitle: "إدارة الغسيل",
+    loginDescription: "سجّل الدخول للوصول إلى النظام",
+    usernameLabel: "اسم المستخدم",
+    passwordLabel: "كلمة المرور",
+    loginButton: "تسجيل الدخول",
+    signingIn: "جاري تسجيل الدخول...",
+    loginSuccess: "تم تسجيل الدخول بنجاح",
+    welcome: "مرحباً بك في نظام إدارة الغسيل",
+    loginFailed: "فشل تسجيل الدخول",
+    missingCredentials: "يرجى إدخال اسم المستخدم وكلمة المرور",
   },
   ur: {
     // Common
@@ -624,6 +657,17 @@ const translations: Record<Language, Translations> = {
     name: "نام",
     newPassword: "نیا پاس ورڈ",
     profileUpdated: "پروفائل اپ ڈیٹ ہو گیا",
+    // Auth
+    loginTitle: "لانڈری مینجمنٹ",
+    loginDescription: "سسٹم تک رسائی کے لیے سائن ان کریں",
+    usernameLabel: "صارف نام",
+    passwordLabel: "پاس ورڈ",
+    loginButton: "سائن ان",
+    signingIn: "سائن ان ہو رہا ہے...",
+    loginSuccess: "لاگ اِن کامیاب",
+    welcome: "لانڈری مینجمنٹ سسٹم میں خوش آمدید",
+    loginFailed: "لاگ اِن ناکام",
+    missingCredentials: "براہ کرم صارف نام اور پاس ورڈ درج کریں",
   }
 };
 


### PR DESCRIPTION
## Summary
- add authentication-related translation keys for English, Arabic, and Urdu
- localize login form labels and toast messages using translation hook

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891011e83f083239ae3b5d3d4e4cca8