### PR TITLE
Add Arabic name support for inventory items and services

### DIFF
--- a/client/src/components/cart-sidebar.tsx
+++ b/client/src/components/cart-sidebar.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { CartSummary } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { getTaxRate } from "@/lib/tax";
+import { useTranslation } from "@/lib/i18n";
 
 interface CartSidebarProps {
   cartSummary: CartSummary;
@@ -30,6 +31,7 @@ export function CartSidebar({
 }: CartSidebarProps) {
   const isMobile = useIsMobile();
   const taxRate = getTaxRate();
+  const { language } = useTranslation();
 
   return (
     <div className={`
@@ -63,12 +65,12 @@ export function CartSidebar({
                   {item.imageUrl && (
                     <img
                       src={item.imageUrl}
-                      alt={item.name}
+                      alt={language === 'ar' && item.nameAr ? item.nameAr : item.name}
                       className="w-12 h-12 rounded object-cover"
                     />
                   )}
                   <div className="flex-1">
-                    <h4 className="font-medium text-gray-900">{item.name}</h4>
+                    <h4 className="font-medium text-gray-900">{language === 'ar' && item.nameAr ? item.nameAr : item.name}</h4>
                     <div className="flex items-center space-x-2 mt-1">
                       <Button
                         variant="secondary"

--- a/client/src/components/clothing-grid.tsx
+++ b/client/src/components/clothing-grid.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClothingItem } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useTranslation } from "@/lib/i18n";
 
 interface ClothingGridProps {
   onSelectClothing: (item: ClothingItem) => void;
@@ -25,6 +26,7 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
+  const { language } = useTranslation();
 
   const { data: clothingItems = [], isLoading } = useQuery({
     queryKey: ["/api/clothing-items", selectedCategory, searchQuery],
@@ -97,12 +99,12 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
                 {item.imageUrl && (
                   <img
                     src={item.imageUrl}
-                    alt={item.name}
+                    alt={language === 'ar' && item.nameAr ? item.nameAr : item.name}
                     className="w-full h-32 object-cover rounded-t-lg"
                   />
                 )}
                 <CardContent className="p-3">
-                  <h3 className="font-medium text-gray-900 mb-1">{item.name}</h3>
+                  <h3 className="font-medium text-gray-900 mb-1">{language === 'ar' && item.nameAr ? item.nameAr : item.name}</h3>
                   {item.description && (
                     <p className="text-sm text-gray-600 mb-2">{item.description}</p>
                   )}

--- a/client/src/components/inventory-management.tsx
+++ b/client/src/components/inventory-management.tsx
@@ -14,6 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ClothingItem, LaundryService, insertClothingItemSchema, insertLaundryServiceSchema } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { useTranslation } from "@/lib/i18n";
 
 export function InventoryManagement() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -21,9 +22,10 @@ export function InventoryManagement() {
   const [isServiceModalOpen, setIsServiceModalOpen] = useState(false);
   const [editingClothing, setEditingClothing] = useState<ClothingItem | null>(null);
   const [editingService, setEditingService] = useState<LaundryService | null>(null);
-  
+
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { language } = useTranslation();
 
   // Fetch clothing items
   const { data: clothingItems = [] } = useQuery({
@@ -48,6 +50,7 @@ export function InventoryManagement() {
     resolver: zodResolver(insertClothingItemSchema),
     defaultValues: {
       name: "",
+      nameAr: "",
       description: "",
       category: "",
       imageUrl: ""
@@ -58,6 +61,7 @@ export function InventoryManagement() {
     resolver: zodResolver(insertLaundryServiceSchema),
     defaultValues: {
       name: "",
+      nameAr: "",
       description: "",
       price: "",
       category: ""
@@ -140,6 +144,7 @@ export function InventoryManagement() {
     setEditingClothing(item);
     clothingForm.reset({
       name: item.name,
+      nameAr: item.nameAr || "",
       description: item.description || "",
       category: item.category,
       imageUrl: item.imageUrl || ""
@@ -151,6 +156,7 @@ export function InventoryManagement() {
     setEditingService(service);
     serviceForm.reset({
       name: service.name,
+      nameAr: service.nameAr || "",
       description: service.description || "",
       price: service.price,
       category: service.category
@@ -161,11 +167,13 @@ export function InventoryManagement() {
   // Filter items based on search
   const filteredClothing = clothingItems.filter(item =>
     item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    item.nameAr?.toLowerCase().includes(searchQuery.toLowerCase()) ||
     item.category.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   const filteredServices = services.filter(service =>
     service.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    service.nameAr?.toLowerCase().includes(searchQuery.toLowerCase()) ||
     service.category.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
@@ -221,6 +229,18 @@ export function InventoryManagement() {
                             <FormLabel>Name</FormLabel>
                             <FormControl>
                               <Input placeholder="e.g., Pants, Shirt" {...field} />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={clothingForm.control}
+                        name="nameAr"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Arabic Name</FormLabel>
+                            <FormControl>
+                              <Input placeholder="الاسم بالعربي" {...field} />
                             </FormControl>
                           </FormItem>
                         )}
@@ -288,7 +308,7 @@ export function InventoryManagement() {
                   <CardContent className="p-4">
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
-                        <h3 className="font-semibold text-gray-900 mb-1">{item.name}</h3>
+                        <h3 className="font-semibold text-gray-900 mb-1">{language === 'ar' && item.nameAr ? item.nameAr : item.name}</h3>
                         <p className="text-sm text-gray-600 mb-2">{item.description}</p>
                         <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded capitalize">
                           {item.category}
@@ -336,6 +356,18 @@ export function InventoryManagement() {
                             <FormLabel>Service Name</FormLabel>
                             <FormControl>
                               <Input placeholder="e.g., Wash & Fold" {...field} />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={serviceForm.control}
+                        name="nameAr"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Arabic Name</FormLabel>
+                            <FormControl>
+                              <Input placeholder="اسم الخدمة بالعربي" {...field} />
                             </FormControl>
                           </FormItem>
                         )}
@@ -401,7 +433,7 @@ export function InventoryManagement() {
                   <CardContent className="p-4">
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
-                        <h3 className="font-semibold text-gray-900 mb-1">{service.name}</h3>
+                        <h3 className="font-semibold text-gray-900 mb-1">{language === 'ar' && service.nameAr ? service.nameAr : service.name}</h3>
                         <p className="text-sm text-gray-600 mb-2">{service.description}</p>
                         <div className="flex items-center justify-between">
                           <span className="text-lg font-bold text-pos-primary">

--- a/client/src/components/laundry-cart-sidebar.tsx
+++ b/client/src/components/laundry-cart-sidebar.tsx
@@ -14,6 +14,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useCurrency } from "@/lib/currency";
+import { useTranslation } from "@/lib/i18n";
 import { getTaxRate } from "@/lib/tax";
 
 interface LaundryCartSidebarProps {
@@ -48,6 +49,7 @@ export function LaundryCartSidebar({
   const queryClient = useQueryClient();
   const { formatCurrency } = useCurrency();
   const taxRate = getTaxRate();
+  const { language } = useTranslation();
 
   const [isCustomerDialogOpen, setIsCustomerDialogOpen] = useState(false);
   const [customerSearch, setCustomerSearch] = useState("");
@@ -264,16 +266,16 @@ export function LaundryCartSidebar({
                     {item.clothingItem.imageUrl && (
                       <img
                         src={item.clothingItem.imageUrl}
-                        alt={item.clothingItem.name}
+                        alt={language === 'ar' && item.clothingItem.nameAr ? item.clothingItem.nameAr : item.clothingItem.name}
                         className="w-12 h-12 rounded object-cover flex-shrink-0"
                       />
                     )}
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-gray-900 truncate">
-                        {item.clothingItem.name}
+                        {language === 'ar' && item.clothingItem.nameAr ? item.clothingItem.nameAr : item.clothingItem.name}
                       </h4>
                       <p className="text-sm text-blue-600 font-medium">
-                        {item.service.name}
+                        {language === 'ar' && item.service.nameAr ? item.service.nameAr : item.service.name}
                       </p>
                       <p className="text-xs text-gray-500">
                         {formatCurrency(item.service.price)} each

--- a/client/src/components/product-grid.tsx
+++ b/client/src/components/product-grid.tsx
@@ -5,10 +5,12 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useTranslation } from "@/lib/i18n";
 
 interface Product {
   id: string;
   name: string;
+  nameAr?: string;
   description?: string;
   category?: string;
   price: string;
@@ -35,6 +37,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart }: Produc
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
+  const { language } = useTranslation();
 
   const { data: products = [], isLoading } = useQuery<Product[]>({
     queryKey: ["/api/products", selectedCategory, searchQuery],
@@ -117,12 +120,12 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart }: Produc
                 {product.imageUrl && (
                   <img
                     src={product.imageUrl}
-                    alt={product.name}
+                    alt={language === 'ar' && product.nameAr ? product.nameAr : product.name}
                     className="w-full h-32 object-cover rounded-t-lg"
                   />
                 )}
                 <CardContent className="p-3">
-                  <h3 className="font-medium text-gray-900 mb-1">{product.name}</h3>
+                  <h3 className="font-medium text-gray-900 mb-1">{language === 'ar' && product.nameAr ? product.nameAr : product.name}</h3>
                   {product.description && (
                     <p className="text-sm text-gray-600 mb-2">{product.description}</p>
                   )}

--- a/client/src/components/service-selection-modal.tsx
+++ b/client/src/components/service-selection-modal.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ClothingItem, LaundryService } from "@shared/schema";
 import { useCurrency } from "@/lib/currency";
+import { useTranslation } from "@/lib/i18n";
 
 interface ServiceSelectionModalProps {
   isOpen: boolean;
@@ -32,6 +33,7 @@ export function ServiceSelectionModal({
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [quantities, setQuantities] = useState<Record<string, number>>({});
   const { formatCurrency } = useCurrency();
+  const { language } = useTranslation();
 
   const { data: services = [] } = useQuery({
     queryKey: ["/api/laundry-services", selectedCategory],
@@ -79,7 +81,7 @@ export function ServiceSelectionModal({
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <span>Select Service for</span>
-            <span className="text-pos-primary">{clothingItem?.name}</span>
+            <span className="text-pos-primary">{language === 'ar' && clothingItem?.nameAr ? clothingItem.nameAr : clothingItem?.name}</span>
           </DialogTitle>
         </DialogHeader>
 
@@ -109,7 +111,7 @@ export function ServiceSelectionModal({
               <CardContent className="p-4">
                 <div className="flex justify-between items-start mb-3">
                   <div className="flex-1">
-                    <h3 className="font-medium text-gray-900 mb-1">{service.name}</h3>
+                    <h3 className="font-medium text-gray-900 mb-1">{language === 'ar' && service.nameAr ? service.nameAr : service.name}</h3>
                     {service.description && (
                       <p className="text-sm text-gray-600 mb-2">{service.description}</p>
                     )}

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -6,7 +6,7 @@ export function useCart() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [paymentMethod, setPaymentMethod] = useState<"cash" | "card">("cash");
 
-  const addToCart = useCallback((product: { id: string; name: string; price: string; imageUrl?: string }) => {
+  const addToCart = useCallback((product: { id: string; name: string; nameAr?: string; price: string; imageUrl?: string }) => {
     setCartItems(prev => {
       const existing = prev.find(item => item.id === product.id);
       if (existing) {
@@ -16,11 +16,12 @@ export function useCart() {
             : item
         );
       }
-      
+
       const price = parseFloat(product.price);
       return [...prev, {
         id: product.id,
         name: product.name,
+        nameAr: product.nameAr,
         price,
         quantity: 1,
         total: price,

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -37,7 +37,7 @@ export default function POS() {
   const isMobile = useIsMobile();
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
   const { formatCurrency } = useCurrency();
   
   const {
@@ -107,7 +107,7 @@ export default function POS() {
     addToCart(clothingItem, service, quantity);
     toast({
       title: "Added to cart",
-      description: `${quantity}x ${clothingItem.name} with ${service.name} service`,
+      description: `${quantity}x ${language === 'ar' && clothingItem.nameAr ? clothingItem.nameAr : clothingItem.name} with ${language === 'ar' && service.nameAr ? service.nameAr : service.name} service`,
     });
   };
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -266,6 +266,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (search) {
         items = items.filter(product =>
           product.name.toLowerCase().includes(search.toLowerCase()) ||
+          product.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
           product.description?.toLowerCase().includes(search.toLowerCase())
         );
       }
@@ -286,8 +287,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         : await storage.getClothingItems();
       
       if (search) {
-        items = items.filter(item => 
+        items = items.filter(item =>
           item.name.toLowerCase().includes(search.toLowerCase()) ||
+          item.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
           item.description?.toLowerCase().includes(search.toLowerCase())
         );
       }
@@ -324,7 +326,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/clothing-items/:id", async (req, res) => {
     try {
       const { id } = req.params;
-      const validatedData = insertClothingItemSchema.parse(req.body);
+      const validatedData = insertClothingItemSchema.partial().parse(req.body);
       const updatedItem = await storage.updateClothingItem(id, validatedData);
       if (!updatedItem) {
         return res.status(404).json({ message: "Clothing item not found" });
@@ -347,8 +349,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         : await storage.getLaundryServices();
       
       if (search) {
-        services = services.filter(service => 
+        services = services.filter(service =>
           service.name.toLowerCase().includes(search.toLowerCase()) ||
+          service.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
           service.description?.toLowerCase().includes(search.toLowerCase())
         );
       }
@@ -385,7 +388,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/laundry-services/:id", async (req, res) => {
     try {
       const { id } = req.params;
-      const validatedData = insertLaundryServiceSchema.parse(req.body);
+      const validatedData = insertLaundryServiceSchema.partial().parse(req.body);
       const updatedService = await storage.updateLaundryService(id, validatedData);
       if (!updatedService) {
         return res.status(404).json({ message: "Laundry service not found" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -310,6 +310,7 @@ export class MemStorage {
     const newProduct: Product = {
       id,
       name: product.name,
+      nameAr: product.nameAr || null,
       description: product.description || null,
       category: product.category || null,
       price: product.price,
@@ -327,6 +328,7 @@ export class MemStorage {
     const updated: Product = {
       ...existing,
       name: product.name ?? existing.name,
+      nameAr: product.nameAr ?? existing.nameAr,
       description: product.description ?? existing.description,
       category: product.category ?? existing.category,
       price: product.price ?? existing.price,
@@ -355,9 +357,10 @@ export class MemStorage {
 
   async createClothingItem(item: InsertClothingItem): Promise<ClothingItem> {
     const id = randomUUID();
-    const newItem: ClothingItem = { 
-      id, 
+    const newItem: ClothingItem = {
+      id,
       name: item.name,
+      nameAr: item.nameAr || null,
       description: item.description || null,
       category: item.category,
       imageUrl: item.imageUrl || null
@@ -369,10 +372,11 @@ export class MemStorage {
   async updateClothingItem(id: string, item: Partial<InsertClothingItem>): Promise<ClothingItem | undefined> {
     const existing = this.clothingItems.get(id);
     if (!existing) return undefined;
-    
-    const updated: ClothingItem = { 
-      ...existing, 
+
+    const updated: ClothingItem = {
+      ...existing,
       name: item.name ?? existing.name,
+      nameAr: item.nameAr ?? existing.nameAr,
       description: item.description ?? existing.description,
       category: item.category ?? existing.category,
       imageUrl: item.imageUrl ?? existing.imageUrl
@@ -399,9 +403,10 @@ export class MemStorage {
 
   async createLaundryService(service: InsertLaundryService): Promise<LaundryService> {
     const id = randomUUID();
-    const newService: LaundryService = { 
-      id, 
+    const newService: LaundryService = {
+      id,
       name: service.name,
+      nameAr: service.nameAr || null,
       description: service.description || null,
       price: service.price,
       category: service.category
@@ -413,10 +418,11 @@ export class MemStorage {
   async updateLaundryService(id: string, service: Partial<InsertLaundryService>): Promise<LaundryService | undefined> {
     const existing = this.laundryServices.get(id);
     if (!existing) return undefined;
-    
-    const updated: LaundryService = { 
-      ...existing, 
+
+    const updated: LaundryService = {
+      ...existing,
       name: service.name ?? existing.name,
+      nameAr: service.nameAr ?? existing.nameAr,
       description: service.description ?? existing.description,
       price: service.price ?? existing.price,
       category: service.category ?? existing.category

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export const clothingItems = pgTable("clothing_items", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
+  nameAr: text("name_ar"),
   description: text("description"),
   category: text("category").notNull(),
   imageUrl: text("image_url"),
@@ -14,6 +15,7 @@ export const clothingItems = pgTable("clothing_items", {
 export const laundryServices = pgTable("laundry_services", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
+  nameAr: text("name_ar"),
   description: text("description"),
   price: decimal("price", { precision: 10, scale: 2 }).notNull(),
   category: text("category").notNull(),
@@ -22,6 +24,7 @@ export const laundryServices = pgTable("laundry_services", {
 export const products = pgTable("products", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
+  nameAr: text("name_ar"),
   description: text("description"),
   category: text("category"),
   price: decimal("price", { precision: 10, scale: 2 }).notNull(),
@@ -264,6 +267,7 @@ export interface LaundryCartItem {
 export interface CartItem {
   id: string;
   name: string;
+  nameAr?: string;
   price: number;
   quantity: number;
   total: number;


### PR DESCRIPTION
## Summary
- add optional `nameAr` columns and insert schemas for products, clothing items, and laundry services
- update storage and routes to handle Arabic names
- collect and show Arabic names in inventory management and selection UIs

## Testing
- `npm run check`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689122a046d48323a5cb60fbe7481351