### PR TITLE
Associate users with branches and surface branch data

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import type { User } from "@shared/schema";
+import type { User, Branch } from "@shared/schema";
+
+type AuthUser = User & { branch?: Branch | null };
 
 export function useAuth() {
-  const { data: user, isLoading, error } = useQuery<User>({
+  const { data: user, isLoading, error } = useQuery<AuthUser>({
     queryKey: ["/api/auth/user"],
     retry: false,
     refetchInterval: false,
@@ -11,6 +13,7 @@ export function useAuth() {
 
   return {
     user,
+    branch: user?.branch,
     isLoading,
     isAuthenticated: !!user && !error,
     isAdmin: user?.role === 'admin' || user?.role === 'super_admin',

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -40,9 +40,8 @@ export default function POS() {
   const queryClient = useQueryClient();
   const { t, language } = useTranslation();
   const { formatCurrency } = useCurrency();
-  const { user } = useAuth();
+  const { user, branch } = useAuth();
   const cashierName = [user?.firstName, user?.lastName].filter(Boolean).join(" ");
-  const branch = (user as any)?.branch;
   
   const {
     cartItems,

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -17,6 +17,7 @@ const hardcodedAdmin: User = {
   lastName: "Admin",
   role: "super_admin",
   isActive: true,
+  branchId: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,7 @@ import { storage } from "./storage";
 import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema, insertSecuritySettingsSchema } from "@shared/schema";
 import { setupAuth, requireAuth, requireSuperAdmin, requireAdminOrSuperAdmin } from "./auth";
 import passport from "passport";
-import type { User } from "@shared/schema";
+import type { UserWithBranch } from "@shared/schema";
 import nodemailer from "nodemailer";
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -47,7 +47,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put("/api/users/:id", requireAuth, async (req, res, next) => {
     const { id } = req.params;
-    const user = req.user as User;
+    const user = req.user as UserWithBranch;
     if (user.id !== id) {
       if (user.role === "super_admin") return next();
       return res.status(403).json({ message: "Unauthorized" });
@@ -71,7 +71,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put("/api/users/:id/password", requireAuth, async (req, res) => {
     const { id } = req.params;
-    const user = req.user as User;
+    const user = req.user as UserWithBranch;
     if (user.id !== id) {
       return res.status(403).json({ message: "Unauthorized" });
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -63,6 +63,7 @@ export const users = pgTable("users", {
   passwordHash: text("password_hash").notNull(),
   firstName: varchar("first_name", { length: 100 }),
   lastName: varchar("last_name", { length: 100 }),
+  branchId: varchar("branch_id").references(() => branches.id),
   role: text("role").notNull().default('user'), // 'super_admin', 'admin', 'user'
   isActive: boolean("is_active").default(true).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -255,6 +256,7 @@ export type LoyaltyHistory = typeof loyaltyHistory.$inferSelect;
 export type InsertLoyaltyHistory = z.infer<typeof insertLoyaltyHistorySchema>;
 export type SecuritySettings = typeof securitySettings.$inferSelect;
 export type InsertSecuritySettings = z.infer<typeof insertSecuritySettingsSchema>;
+export type UserWithBranch = User & { branch: Branch | null };
 
 export interface LaundryCartItem {
   id: string;


### PR DESCRIPTION
## Summary
- add `branchId` foreign key to users table and export `UserWithBranch`
- join branches in user storage operations and return branch data via routes
- allow admins to assign user branches and expose branch via `useAuth`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68912a94930c8323b4e86edd0fc82fd9