### PR TITLE
fix: keep Arabic phone numbers left-to-right

### DIFF
--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -213,7 +213,9 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
             )}
             <div className="flex">
               <p className="flex-1 text-gray-600">{branchPhone}</p>
-              <p className="flex-1 text-gray-600 text-right" dir="rtl">{branchPhone}</p>
+              <p className="flex-1 text-gray-600 text-right" dir="rtl">
+                <span dir="ltr">{branchPhone}</span>
+              </p>
             </div>
           </div>
 
@@ -395,7 +397,7 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
                 {tEn.inquiriesCall} {branchPhone}
               </p>
               <p className="flex-1 text-right" dir="rtl">
-                {tAr.inquiriesCall} {branchPhone}
+                {tAr.inquiriesCall} <span dir="ltr">{branchPhone}</span>
               </p>
             </div>
             {isPayLater && (


### PR DESCRIPTION
## Summary
- wrap Arabic receipt phone numbers in an LTR span to maintain digit order

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68912daa1be8832381cd0c13a16ba63a