### PR TITLE
Use authenticated username for receipts

### DIFF
--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -52,6 +52,8 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
   const branchPhone = receiptData?.branchPhone || '+965-2XXX-XXXX';
   if (!receiptData) return null;
 
+  const staffName = receiptData.cashierName || receiptData.createdBy;
+
   const paymentMethodKey =
     receiptData.paymentMethod === 'pay_later'
       ? 'payLater'
@@ -238,19 +240,12 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
               isPayLater ? tAr.orderNumber : tAr.receiptNumber,
               receiptData.id.slice(-6).toUpperCase()
             )}
-            {receiptData.cashierName &&
+            {staffName &&
               renderBilingualRow(
                 tEn.staff,
-                receiptData.cashierName,
+                staffName,
                 tAr.staff,
-                receiptData.cashierName
-              )}
-            {receiptData.createdBy &&
-              renderBilingualRow(
-                tEn.staff,
-                receiptData.createdBy,
-                tAr.staff,
-                receiptData.createdBy
+                staffName
               )}
             {customer &&
               renderBilingualRow(

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -41,7 +41,7 @@ export default function POS() {
   const { t, language } = useTranslation();
   const { formatCurrency } = useCurrency();
   const { user, branch } = useAuth();
-  const cashierName = [user?.firstName, user?.lastName].filter(Boolean).join(" ");
+  const username = user?.username ?? "";
   
   const {
     cartItems,
@@ -75,7 +75,7 @@ export default function POS() {
           branchName: branch?.name,
           branchAddress: branch?.address,
           branchPhone: branch?.phone,
-          createdBy: cashierName,
+          createdBy: username,
         });
         setCurrentTransaction(null);
         toast({
@@ -85,7 +85,7 @@ export default function POS() {
       } else {
         setCurrentTransaction({
           ...result,
-          cashierName,
+          cashierName: username,
           branchName: branch?.name,
           branchAddress: branch?.address,
           branchPhone: branch?.phone,
@@ -171,7 +171,7 @@ export default function POS() {
         paymentMethod: "pay_later",
         status: "received",
         estimatedPickupDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days from now
-        createdBy: cashierName,
+        createdBy: username,
         branchName: branch?.name,
         branchAddress: branch?.address,
         branchPhone: branch?.phone,
@@ -187,7 +187,7 @@ export default function POS() {
         tax: cartSummary.tax.toString(),
         total: finalTotal.toString(),
         paymentMethod,
-        cashierName,
+        cashierName: username,
         branchName: branch?.name,
         branchAddress: branch?.address,
         branchPhone: branch?.phone,


### PR DESCRIPTION
## Summary
- replace hardcoded cashier name with `user.username` when creating transactions and orders
- surface the username in the receipt modal via a shared `staffName` field

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68912f4edcec8323b1f5753371a70669