### PR TITLE
feat: unify seller name field

### DIFF
--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -68,7 +68,7 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
   const branchPhone = receiptData?.branchPhone || '+965-2XXX-XXXX';
   if (!receiptData) return null;
 
-  const staffName = receiptData.cashierName || receiptData.createdBy;
+  const sellerName = receiptData.sellerName;
 
   const paymentMethodKey =
     receiptData.paymentMethod === 'pay_later'
@@ -264,12 +264,12 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
               isPayLater ? tAr.orderNumber : tAr.receiptNumber,
               receiptData.id.slice(-6).toUpperCase()
             )}
-            {staffName &&
+            {sellerName &&
               renderBilingualRow(
                 tEn.staff,
-                staffName,
+                sellerName,
                 tAr.staff,
-                staffName
+                sellerName
               )}
             {customer &&
               renderBilingualRow(

--- a/client/src/components/reports-dashboard.tsx
+++ b/client/src/components/reports-dashboard.tsx
@@ -264,7 +264,7 @@ export function ReportsDashboard() {
                           {format(new Date(transaction.createdAt), 'MMM dd, yyyy HH:mm')}
                         </div>
                         <div className="text-sm text-gray-600 capitalize">
-                          {transaction.paymentMethod} • {transaction.cashierName}
+                          {transaction.paymentMethod} • {transaction.sellerName}
                         </div>
                       </div>
                       <div className="text-right">

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -75,7 +75,7 @@ export default function POS() {
           branchName: branch?.name,
           branchAddress: branch?.address,
           branchPhone: branch?.phone,
-          createdBy: username,
+          sellerName: username,
         });
         setCurrentTransaction(null);
         toast({
@@ -85,7 +85,7 @@ export default function POS() {
       } else {
         setCurrentTransaction({
           ...result,
-          cashierName: username,
+          sellerName: username,
           branchName: branch?.name,
           branchAddress: branch?.address,
           branchPhone: branch?.phone,
@@ -171,7 +171,7 @@ export default function POS() {
         paymentMethod: "pay_later",
         status: "received",
         estimatedPickupDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days from now
-        createdBy: username,
+        sellerName: username,
         branchName: branch?.name,
         branchAddress: branch?.address,
         branchPhone: branch?.phone,
@@ -187,7 +187,7 @@ export default function POS() {
         tax: cartSummary.tax.toString(),
         total: finalTotal.toString(),
         paymentMethod,
-        cashierName: username,
+        sellerName: username,
         branchName: branch?.name,
         branchAddress: branch?.address,
         branchPhone: branch?.phone,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -40,7 +40,7 @@ export const transactions = pgTable("transactions", {
   total: decimal("total", { precision: 10, scale: 2 }).notNull(),
   paymentMethod: text("payment_method").notNull(),
   createdAt: timestamp("created_at").default(sql`now()`).notNull(),
-  cashierName: text("cashier_name").notNull(),
+  sellerName: text("seller_name").notNull(),
 });
 
 // Session storage table.
@@ -120,7 +120,7 @@ export const orders = pgTable("orders", {
   estimatedPickup: timestamp("estimated_pickup"),
   actualPickup: timestamp("actual_pickup"),
   notes: text("notes"),
-  createdBy: varchar("created_by").notNull(),
+  sellerName: varchar("seller_name").notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary
- standardize schema to use `sellerName` for transactions and orders
- display seller name once in receipts and reports
- update POS flow to send seller details consistently

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891331e5960832386cab5c28ee0f7bf