### PR TITLE
Include name field for items in orders and receipts

### DIFF
--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -293,11 +293,11 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
               <div key={index} className="space-y-1">
                 <div className="flex">
                   <div className="flex-1 flex justify-between">
-                    <span className="flex-1">{item.name}</span>
+                    <span className="flex-1">{item.name || item.clothingItem}</span>
                     <span>{formatCurrency(item.total)}</span>
                   </div>
                   <div className="flex-1 flex justify-between text-right" dir="rtl">
-                    <span className="flex-1">{item.name}</span>
+                    <span className="flex-1">{item.name || item.clothingItem}</span>
                     <span>{formatCurrency(item.total)}</span>
                   </div>
                 </div>

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -151,6 +151,7 @@ export default function POS() {
     // Convert laundry cart items to order format
     const orderItems = cartSummary.items.map(item => ({
       id: item.id,
+      name: item.clothingItem.name,
       clothingItem: item.clothingItem.name,
       service: item.service.name,
       quantity: item.quantity,


### PR DESCRIPTION
## Summary
- add item.name to POS cart-to-order mapping for pay-later and immediate flows
- show item.name or fallback clothingItem in receipt modal

## Testing
- `npm run check`
- `node -e "const cartSummary={items:[{id:'1', clothingItem:{name:'Shirt'}, service:{name:'Wash',price:'5'}, quantity:2, total:10}]}; const orderItems = cartSummary.items.map(item=>({id:item.id, name:item.clothingItem.name, clothingItem:item.clothingItem.name, service:item.service.name, quantity:item.quantity, price:parseFloat(item.service.price), total:item.total})); const payLaterOrder={items:orderItems, paymentMethod:'pay_later'}; const immediateTrans={items:orderItems, paymentMethod:'cash'}; console.log('payLater item:', payLaterOrder.items[0]); console.log('immediate item:', immediateTrans.items[0]);"`

------
https://chatgpt.com/codex/tasks/task_e_689135d6b3048323b0cb2666bb9c0a10