### PR TITLE
Use object items for orders

### DIFF
--- a/client/src/components/business-reports.tsx
+++ b/client/src/components/business-reports.tsx
@@ -95,13 +95,13 @@ export function BusinessReports() {
     items.forEach((item: any) => {
       // Try multiple ways to get service name
       let serviceName = 'Unknown Service';
-      
-      if (item.service?.name) {
+
+      if (typeof item.service === 'string') {
+        serviceName = item.service;
+      } else if (item.service?.name) {
         serviceName = item.service.name;
       } else if (item.serviceName) {
         serviceName = item.serviceName;
-      } else if (item.service) {
-        serviceName = typeof item.service === 'string' ? item.service : 'Unknown Service';
       } else if (item.serviceId && laundryServices.length > 0) {
         // Look up service by ID
         const service = laundryServices.find(s => s.id === item.serviceId);

--- a/client/src/components/order-tracking.tsx
+++ b/client/src/components/order-tracking.tsx
@@ -82,8 +82,12 @@ export function OrderTracking() {
 
   const getItemsSummary = (items: any[]) => {
     return items.map(item => {
-      const clothingName = item.clothingItem?.name || 'Item';
-      const serviceName = item.service?.name || 'Service';
+      const clothingName = typeof item.clothingItem === 'string'
+        ? item.clothingItem
+        : item.clothingItem?.name || 'Item';
+      const serviceName = typeof item.service === 'string'
+        ? item.service
+        : item.service?.name || 'Service';
       return `${item.quantity}x ${clothingName} (${serviceName})`;
     }).join(", ");
   };
@@ -181,8 +185,8 @@ export function OrderTracking() {
                     <div className="space-y-1">
                       {items.slice(0, 3).map((item, index) => (
                         <div key={index} className="text-sm flex justify-between">
-                          <span>{item.quantity}x {item.clothingItem?.name || 'Item'}</span>
-                          <span className="text-gray-500">({item.service?.name || 'Service'})</span>
+                          <span>{item.quantity}x {typeof item.clothingItem === 'string' ? item.clothingItem : item.clothingItem?.name || 'Item'}</span>
+                          <span className="text-gray-500">({typeof item.service === 'string' ? item.service : item.service?.name || 'Service'})</span>
                         </div>
                       ))}
                       {items.length > 3 && (

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -152,8 +152,8 @@ export default function POS() {
     const orderItems = cartSummary.items.map(item => ({
       id: item.id,
       name: item.clothingItem.name,
-      clothingItem: item.clothingItem.name,
-      service: item.service.name,
+      clothingItem: { name: item.clothingItem.name },
+      service: { name: item.service.name },
       quantity: item.quantity,
       price: parseFloat(item.service.price),
       total: item.total


### PR DESCRIPTION
## Summary
- Nest clothing and service data in order items
- Gracefully read legacy items as strings in OrderTracking
- Teach BusinessReports to handle new item structure

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689137b84e388323a006fd601ca0a3b8