### PR TITLE
feat: enforce branch-level data access

### DIFF
--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -173,9 +173,6 @@ export default function POS() {
         status: "received",
         estimatedPickupDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days from now
         sellerName: username,
-        branchName: branch?.name,
-        branchAddress: branch?.address,
-        branchPhone: branch?.phone,
         loyaltyPointsEarned: pointsEarned,
         loyaltyPointsRedeemed: redeemedPoints,
       };
@@ -189,9 +186,6 @@ export default function POS() {
         total: finalTotal.toString(),
         paymentMethod,
         sellerName: username,
-        branchName: branch?.name,
-        branchAddress: branch?.address,
-        branchPhone: branch?.phone,
         customerId: selectedCustomer?.id,
         loyaltyPointsEarned: pointsEarned,
         loyaltyPointsRedeemed: redeemedPoints,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -41,6 +41,7 @@ export const transactions = pgTable("transactions", {
   paymentMethod: text("payment_method").notNull(),
   createdAt: timestamp("created_at").default(sql`now()`).notNull(),
   sellerName: text("seller_name").notNull(),
+  branchId: varchar("branch_id").references(() => branches.id).notNull(),
 });
 
 // Session storage table.
@@ -121,6 +122,7 @@ export const orders = pgTable("orders", {
   actualPickup: timestamp("actual_pickup"),
   notes: text("notes"),
   sellerName: varchar("seller_name").notNull(),
+  branchId: varchar("branch_id").references(() => branches.id).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
@@ -186,6 +188,7 @@ export const insertOrderSchema = createInsertSchema(orders).omit({
   orderNumber: true,
   createdAt: true,
   updatedAt: true,
+  branchId: true,
 });
 
 export const insertPaymentSchema = createInsertSchema(payments).omit({
@@ -206,6 +209,7 @@ export const insertSecuritySettingsSchema = createInsertSchema(securitySettings)
 export const insertTransactionSchema = createInsertSchema(transactions).omit({
   id: true,
   createdAt: true,
+  branchId: true,
 });
 
 export const insertLoyaltyHistorySchema = createInsertSchema(loyaltyHistory).omit({


### PR DESCRIPTION
## Summary
- scope orders and transactions to authenticated user's branch
- add branchId column to orders and transactions schema
- filter payments and reports by branch, remove client branch fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891390d00e483239f2b0e71a4ba3bda