### PR TITLE
feat: allow partial user updates

### DIFF
--- a/client/src/components/admin/UserManager.tsx
+++ b/client/src/components/admin/UserManager.tsx
@@ -59,7 +59,7 @@ export function UserManager() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: InsertUser }) => {
+    mutationFn: async ({ id, data }: { id: string; data: Partial<InsertUser> }) => {
       const response = await apiRequest("PUT", `/api/users/${id}`, data);
       return await response.json();
     },
@@ -110,7 +110,19 @@ export function UserManager() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (editingUser) {
-      updateMutation.mutate({ id: editingUser.id, data: formData });
+      const updates: Partial<InsertUser> = {};
+      (Object.keys(formData) as (keyof InsertUser)[]).forEach((key) => {
+        const newValue = formData[key];
+        const oldValue = editingUser[key as keyof UserWithBranch];
+          if (key === "passwordHash") {
+            if (newValue) {
+              updates[key] = newValue as any;
+            }
+          } else if (newValue !== oldValue) {
+            updates[key] = newValue as any;
+          }
+      });
+      updateMutation.mutate({ id: editingUser.id, data: updates });
     } else {
       createMutation.mutate(formData);
     }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema, insertSecuritySettingsSchema } from "@shared/schema";
+import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertUserSchema, updateUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema, insertSecuritySettingsSchema } from "@shared/schema";
 import { setupAuth, requireAuth, requireSuperAdmin, requireAdminOrSuperAdmin } from "./auth";
 import passport from "passport";
 import type { UserWithBranch } from "@shared/schema";
@@ -116,7 +116,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/users/:id", requireSuperAdmin, async (req, res) => {
     try {
       const { id } = req.params;
-      const validatedData = insertUserSchema.parse(req.body);
+      const validatedData = updateUserSchema.parse(req.body);
+      if (validatedData.passwordHash === "") {
+        delete validatedData.passwordHash;
+      }
       const updatedUser = await storage.updateUser(id, validatedData);
       if (!updatedUser) {
         return res.status(404).json({ message: "User not found" });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -223,6 +223,9 @@ export const insertUserSchema = createInsertSchema(users).omit({
   updatedAt: true,
 });
 
+// Schema for updating users where all fields are optional
+export const updateUserSchema = insertUserSchema.partial();
+
 export const insertCategorySchema = createInsertSchema(categories).omit({
   id: true,
   createdAt: true,
@@ -235,6 +238,7 @@ export const insertBranchSchema = createInsertSchema(branches).omit({
 
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
+export type UpdateUser = z.infer<typeof updateUserSchema>;
 export type UpsertUser = typeof users.$inferInsert;
 export type ClothingItem = typeof clothingItems.$inferSelect;
 export type InsertClothingItem = z.infer<typeof insertClothingItemSchema>;


### PR DESCRIPTION
## Summary
- add `updateUserSchema` with all user fields optional
- allow super-admin to update users without supplying a password
- send only changed fields from `UserManager` when updating a user

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689142535f988323a771bfdae4edb6f0