### PR TITLE
fix: avoid clearing password when updating user

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --import tsx --test server/storage.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
+
+const { DatabaseStorage } = await import('./storage');
+const { db } = await import('./db');
+
+const baseUser = {
+  id: '1',
+  username: 'test',
+  firstName: 'Old',
+  lastName: 'User',
+  email: 'test@example.com',
+  role: 'user',
+  branchId: null,
+  passwordHash: 'existing-hash',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+test('updateUser without password leaves existing hash untouched', async () => {
+  const user = { ...baseUser };
+  const originalUpdate = db.update;
+  const originalSelect = db.select;
+  let setData: any = null;
+
+  (db as any).update = () => ({
+    set: (data: any) => {
+      setData = data;
+      Object.assign(user, data);
+      return {
+        where: () => ({
+          returning: () => [{ id: user.id }],
+        }),
+      };
+    },
+  });
+
+  (db as any).select = () => ({
+    from: () => ({
+      leftJoin: () => ({
+        where: () => [{ user, branch: null }],
+      }),
+    }),
+  });
+
+  const storage = new DatabaseStorage();
+  const updated = await storage.updateUser(user.id, { firstName: 'New' });
+
+  (db as any).update = originalUpdate;
+  (db as any).select = originalSelect;
+
+  assert.strictEqual(setData.passwordHash, undefined);
+  assert.strictEqual(updated?.passwordHash, baseUser.passwordHash);
+});
+
+test('updateUser with empty password string leaves existing hash untouched', async () => {
+  const user = { ...baseUser };
+  const originalUpdate = db.update;
+  const originalSelect = db.select;
+  let setData: any = null;
+
+  (db as any).update = () => ({
+    set: (data: any) => {
+      setData = data;
+      Object.assign(user, data);
+      return {
+        where: () => ({
+          returning: () => [{ id: user.id }],
+        }),
+      };
+    },
+  });
+
+  (db as any).select = () => ({
+    from: () => ({
+      leftJoin: () => ({
+        where: () => [{ user, branch: null }],
+      }),
+    }),
+  });
+
+  const storage = new DatabaseStorage();
+  const updated = await storage.updateUser(user.id, { firstName: 'New', passwordHash: '' });
+
+  (db as any).update = originalUpdate;
+  (db as any).select = originalSelect;
+
+  assert.strictEqual(setData.passwordHash, undefined);
+  assert.strictEqual(updated?.passwordHash, baseUser.passwordHash);
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -575,10 +575,18 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateUser(id: string, userData: Partial<InsertUser>): Promise<UserWithBranch | undefined> {
-    const updateData = { ...userData };
-    if (updateData.passwordHash) {
-      const saltRounds = 10;
-      updateData.passwordHash = await bcrypt.hash(updateData.passwordHash, saltRounds);
+    const updateData = { ...userData } as Partial<InsertUser>;
+
+    if ("passwordHash" in updateData) {
+      if (typeof updateData.passwordHash !== "string") {
+        throw new Error("passwordHash must be a non-empty string");
+      }
+      if (updateData.passwordHash) {
+        const saltRounds = 10;
+        updateData.passwordHash = await bcrypt.hash(updateData.passwordHash, saltRounds);
+      } else {
+        delete updateData.passwordHash;
+      }
     }
 
     const [updated] = await db


### PR DESCRIPTION
## Summary
- validate and hash password only when provided and non-empty
- add tests covering user updates without password changes

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689143d6291c8323827c603fe317e708