### PR TITLE
Add delete endpoints for clothing items and services

### DIFF
--- a/server/routes.auth.test.ts
+++ b/server/routes.auth.test.ts
@@ -23,6 +23,8 @@ function createApp(user?: { role: string }) {
   app.put('/api/clothing-items/:id', requireAdminOrSuperAdmin, (_req, res) => res.json({ ok: true }));
   app.post('/api/laundry-services', requireAdminOrSuperAdmin, (_req, res) => res.json({ ok: true }));
   app.put('/api/laundry-services/:id', requireAdminOrSuperAdmin, (_req, res) => res.json({ ok: true }));
+  app.delete('/api/clothing-items/:id', requireAdminOrSuperAdmin, (_req, res) => res.json({ ok: true }));
+  app.delete('/api/laundry-services/:id', requireAdminOrSuperAdmin, (_req, res) => res.json({ ok: true }));
   return app;
 }
 
@@ -32,6 +34,8 @@ test('non-admin requests receive 403', async () => {
   await request(app).put('/api/clothing-items/1').send({}).expect(403);
   await request(app).post('/api/laundry-services').send({}).expect(403);
   await request(app).put('/api/laundry-services/1').send({}).expect(403);
+  await request(app).delete('/api/clothing-items/1').expect(403);
+  await request(app).delete('/api/laundry-services/1').expect(403);
 });
 
 test('admin requests can modify items', async () => {
@@ -44,4 +48,8 @@ test('admin requests can modify items', async () => {
   assert.equal(res3.status, 200);
   const res4 = await request(app).put('/api/laundry-services/1').send({});
   assert.equal(res4.status, 200);
+  const res5 = await request(app).delete('/api/clothing-items/1');
+  assert.equal(res5.status, 200);
+  const res6 = await request(app).delete('/api/laundry-services/1');
+  assert.equal(res6.status, 200);
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -383,6 +383,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete("/api/clothing-items/:id", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      const deleted = await storage.deleteClothingItem(id);
+      if (!deleted) {
+        return res.status(404).json({ message: "Clothing item not found" });
+      }
+      res.json({ message: "Clothing item deleted successfully" });
+    } catch (error) {
+      console.error("Error deleting clothing item:", error);
+      res.status(500).json({ message: "Failed to delete clothing item" });
+    }
+  });
+
   // Laundry Services routes
   app.get("/api/laundry-services", async (req, res) => {
     try {
@@ -442,6 +456,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error updating laundry service:", error);
       res.status(500).json({ message: "Failed to update laundry service" });
+    }
+  });
+
+  app.delete("/api/laundry-services/:id", requireAdminOrSuperAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      const deleted = await storage.deleteLaundryService(id);
+      if (!deleted) {
+        return res.status(404).json({ message: "Laundry service not found" });
+      }
+      res.json({ message: "Laundry service deleted successfully" });
+    } catch (error) {
+      console.error("Error deleting laundry service:", error);
+      res.status(500).json({ message: "Failed to delete laundry service" });
     }
   });
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -126,3 +126,23 @@ test('updateUserBranch updates branch only', async () => {
   assert.strictEqual(setData.branchId, 'b1');
   assert.strictEqual(updated?.branchId, 'b1');
 });
+
+test('deleteClothingItem returns boolean based on deletion result', async () => {
+  const storage = new DatabaseStorage();
+  const originalDelete = db.delete;
+  (db as any).delete = () => ({ where: () => ({ rowCount: 1 }) });
+  assert.strictEqual(await storage.deleteClothingItem('1'), true);
+  (db as any).delete = () => ({ where: () => ({ rowCount: 0 }) });
+  assert.strictEqual(await storage.deleteClothingItem('1'), false);
+  (db as any).delete = originalDelete;
+});
+
+test('deleteLaundryService returns boolean based on deletion result', async () => {
+  const storage = new DatabaseStorage();
+  const originalDelete = db.delete;
+  (db as any).delete = () => ({ where: () => ({ rowCount: 1 }) });
+  assert.strictEqual(await storage.deleteLaundryService('1'), true);
+  (db as any).delete = () => ({ where: () => ({ rowCount: 0 }) });
+  assert.strictEqual(await storage.deleteLaundryService('1'), false);
+  (db as any).delete = originalDelete;
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -68,13 +68,15 @@ export interface IStorage {
   getClothingItem(id: string): Promise<ClothingItem | undefined>;
   createClothingItem(item: InsertClothingItem): Promise<ClothingItem>;
   updateClothingItem(id: string, item: Partial<InsertClothingItem>): Promise<ClothingItem | undefined>;
-  
+  deleteClothingItem(id: string): Promise<boolean>;
+
   // Laundry Services
   getLaundryServices(): Promise<LaundryService[]>;
   getLaundryServicesByCategory(categoryId: string): Promise<LaundryService[]>;
   getLaundryService(id: string): Promise<LaundryService | undefined>;
   createLaundryService(service: InsertLaundryService): Promise<LaundryService>;
   updateLaundryService(id: string, service: Partial<InsertLaundryService>): Promise<LaundryService | undefined>;
+  deleteLaundryService(id: string): Promise<boolean>;
   
   // Transactions
   createTransaction(transaction: InsertTransaction & { branchId: string }): Promise<Transaction>;
@@ -392,6 +394,10 @@ export class MemStorage {
     return updated;
   }
 
+  async deleteClothingItem(id: string): Promise<boolean> {
+    return this.clothingItems.delete(id);
+  }
+
   // Laundry Services methods
   async getLaundryServices(): Promise<LaundryService[]> {
     return Array.from(this.laundryServices.values());
@@ -436,6 +442,10 @@ export class MemStorage {
     };
     this.laundryServices.set(id, updated);
     return updated;
+  }
+
+  async deleteLaundryService(id: string): Promise<boolean> {
+    return this.laundryServices.delete(id);
   }
 
   async createTransaction(insertTransaction: InsertTransaction & { branchId: string }): Promise<Transaction> {
@@ -775,6 +785,11 @@ export class DatabaseStorage implements IStorage {
     return updated || undefined;
   }
 
+  async deleteClothingItem(id: string): Promise<boolean> {
+    const result = await db.delete(clothingItems).where(eq(clothingItems.id, id));
+    return result.rowCount ? result.rowCount > 0 : false;
+  }
+
   // Laundry Services methods
   async getLaundryServices(): Promise<LaundryService[]> {
     return await db.select().from(laundryServices);
@@ -807,6 +822,11 @@ export class DatabaseStorage implements IStorage {
       .where(eq(laundryServices.id, id))
       .returning();
     return updated || undefined;
+  }
+
+  async deleteLaundryService(id: string): Promise<boolean> {
+    const result = await db.delete(laundryServices).where(eq(laundryServices.id, id));
+    return result.rowCount ? result.rowCount > 0 : false;
   }
 
   // Transactions methods


### PR DESCRIPTION
## Summary
- allow admins to delete clothing items or laundry services with proper error handling
- support deletion in both memory and database storage layers
- test delete permissions and storage deletion behavior

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891c773f440832391886d4d23921377