### PR TITLE
fix: handle unassigned branch sentinel in user manager

### DIFF
--- a/client/src/components/admin/UserManager.tsx
+++ b/client/src/components/admin/UserManager.tsx
@@ -271,16 +271,19 @@ export function UserManager() {
                     Branch
                   </Label>
                   <Select
-                    value={formData.branchId || ""}
+                    value={formData.branchId ?? "unassigned"}
                     onValueChange={(value) =>
-                      setFormData({ ...formData, branchId: value === "" ? null : value })
+                      setFormData({
+                        ...formData,
+                        branchId: value === "unassigned" ? undefined : value,
+                      })
                     }
                   >
                     <SelectTrigger className="col-span-3">
                       <SelectValue placeholder="Select branch" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Unassigned</SelectItem>
+                      <SelectItem value="unassigned">Unassigned</SelectItem>
                       {branches.map((branch) => (
                         <SelectItem key={branch.id} value={branch.id}>
                           {branch.name}


### PR DESCRIPTION
## Summary
- use explicit "unassigned" sentinel for branch selection
- map sentinel back to undefined when updating user form

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d1302a388323945e161dea94571f