### PR TITLE
Seed default categories and validate clothing item category

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -112,6 +112,7 @@ Preferred communication style: Simple, everyday language.
 - **Path Aliases**: Configured for clean imports (`@/`, `@shared/`)
 - **Build Scripts**: Separate development and production build processes
 - **Database Setup**: Drizzle migrations handle schema deployment
+- **Initial Categories**: Seed categories (e.g., pants, shirts) before adding clothing items
 
 ## Recent Changes (July 2025)
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
+import { seedInitialCategories } from "./storage";
 import { setupVite, serveStatic, log } from "./vite";
 
 // Set SESSION_SECRET if not present
@@ -44,6 +45,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  await seedInitialCategories();
   const server = await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -360,10 +360,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/clothing-items", requireAdminOrSuperAdmin, async (req, res) => {
     try {
       const validatedData = insertClothingItemSchema.parse(req.body);
+      const category = await storage.getCategory(validatedData.categoryId);
+      if (!category) {
+        return res.status(400).json({ message: "Invalid category" });
+      }
       const newItem = await storage.createClothingItem(validatedData);
       res.json(newItem);
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error creating clothing item:", error);
+      if (error?.code === "23503") {
+        return res.status(400).json({ message: "Invalid category" });
+      }
       res.status(500).json({ message: "Failed to create clothing item" });
     }
   });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1192,4 +1192,14 @@ export class DatabaseStorage implements IStorage {
   }
 }
 
+export async function seedInitialCategories(): Promise<void> {
+  await db
+    .insert(categories)
+    .values([
+      { name: "pants", type: "clothing", description: "Pants", isActive: true },
+      { name: "shirts", type: "clothing", description: "Shirts", isActive: true },
+    ])
+    .onConflictDoNothing();
+}
+
 export const storage = new DatabaseStorage();


### PR DESCRIPTION
## Summary
- seed default "pants" and "shirts" categories to satisfy foreign keys
- ensure clothing item creation validates category existence and maps FK errors
- document need to seed categories before creating clothing items

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891d48a4d048323ba59f696d4586941