### PR TITLE
feat: add catalog bulk upload

### DIFF
--- a/client/src/components/admin/BulkUploadManager.tsx
+++ b/client/src/components/admin/BulkUploadManager.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import type { Branch } from "@shared/schema";
+
+export function BulkUploadManager() {
+  const { data: branches = [] } = useQuery<Branch[]>({
+    queryKey: ["/api/branches"],
+  });
+  const { toast } = useToast();
+  const [branchId, setBranchId] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const downloadTemplate = async () => {
+    try {
+      const res = await fetch("/api/catalog/bulk-template", { credentials: "include" });
+      if (!res.ok) throw new Error(await res.text());
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "catalog-bulk-template.xlsx";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      toast({
+        title: "Download failed",
+        description: err.message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const uploadMutation = useMutation({
+    mutationFn: async () => {
+      if (!file || !branchId) throw new Error("Please select a branch and file");
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("branchId", branchId);
+      const res = await fetch("/api/catalog/bulk-upload", {
+        method: "POST",
+        body: formData,
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return await res.json();
+    },
+    onSuccess: () => {
+      setStatus("Upload successful");
+      setError(null);
+      toast({ title: "Upload successful" });
+      setFile(null);
+    },
+    onError: (err: any) => {
+      setError(err.message);
+      setStatus(null);
+      toast({
+        title: "Upload failed",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleUpload = () => {
+    uploadMutation.mutate();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bulk Upload</CardTitle>
+        <CardDescription>Upload catalog items using an Excel template</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="branch">Branch</Label>
+          <Select value={branchId} onValueChange={setBranchId}>
+            <SelectTrigger id="branch" className="w-[240px]">
+              <SelectValue placeholder="Select branch" />
+            </SelectTrigger>
+            <SelectContent>
+              {branches.map((b) => (
+                <SelectItem key={b.id} value={b.id}>
+                  {b.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button variant="outline" onClick={downloadTemplate}>
+          Download Template
+        </Button>
+        <div className="space-y-2">
+          <Label htmlFor="file">Excel File</Label>
+          <Input
+            id="file"
+            type="file"
+            accept=".xlsx"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+        </div>
+        <Button
+          onClick={handleUpload}
+          disabled={uploadMutation.isPending || !file || !branchId}
+        >
+          {uploadMutation.isPending ? "Uploading..." : "Upload"}
+        </Button>
+        {status && <p className="text-green-600">{status}</p>}
+        {error && <p className="text-red-600">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
@@ -9,7 +7,8 @@ import { apiRequest } from "@/lib/queryClient";
 import { CategoryManager } from "@/components/admin/CategoryManager";
 import { UserManager } from "@/components/admin/UserManager";
 import { BranchManager } from "@/components/admin/BranchManager";
-import { LogOut, Users, Tags, MapPin, ArrowLeft } from "lucide-react";
+import { BulkUploadManager } from "@/components/admin/BulkUploadManager";
+import { LogOut, Users, Tags, MapPin, ArrowLeft, Upload } from "lucide-react";
 import { Link } from "wouter";
 import logoUrl from "@/assets/logo.png";
 
@@ -87,7 +86,7 @@ export default function AdminDashboard() {
         </div>
 
         <Tabs defaultValue="categories" className="space-y-6">
-          <TabsList className={`grid w-full ${isSuperAdmin ? "grid-cols-3" : "grid-cols-1"}`}>
+          <TabsList className={`grid w-full ${isSuperAdmin ? "grid-cols-4" : "grid-cols-1"}`}>
             <TabsTrigger value="categories" className="flex items-center gap-2">
               <Tags className="w-4 h-4" />
               Categories
@@ -101,6 +100,10 @@ export default function AdminDashboard() {
                 <TabsTrigger value="users" className="flex items-center gap-2">
                   <Users className="w-4 h-4" />
                   Users
+                </TabsTrigger>
+                <TabsTrigger value="bulk-upload" className="flex items-center gap-2">
+                  <Upload className="w-4 h-4" />
+                  Bulk Upload
                 </TabsTrigger>
               </>
             )}
@@ -119,6 +122,12 @@ export default function AdminDashboard() {
           {isSuperAdmin && (
             <TabsContent value="users" className="space-y-6">
               <UserManager />
+            </TabsContent>
+          )}
+
+          {isSuperAdmin && (
+            <TabsContent value="bulk-upload" className="space-y-6">
+              <BulkUploadManager />
             </TabsContent>
           )}
         </Tabs>


### PR DESCRIPTION
## Summary
- allow super admins to bulk upload catalog items from admin dashboard
- manage catalog uploads with branch selector and status updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923c62cb1083238144eded45757704