### PR TITLE
Add image URL support to catalog bulk upload

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -274,6 +274,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
               r["Urgent Wash & Iron"] !== undefined
                 ? Number(r["Urgent Wash & Iron"])
                 : undefined,
+            imageUrl: r["Picture Link"]
+              ? String(r["Picture Link"]).trim()
+              : undefined,
           }))
           .filter((r) => r.itemEn);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface ParsedRow {
   urgentIron?: number;
   urgentWash?: number;
   urgentWashIron?: number;
+  imageUrl?: string;
 }
 
 export interface IStorage {
@@ -1025,12 +1026,13 @@ export class DatabaseStorage implements IStorage {
           if (existingItem) {
             await tx
               .update(clothingItems)
-              .set({ nameAr: row.itemAr })
+              .set({ nameAr: row.itemAr, imageUrl: row.imageUrl })
               .where(eq(clothingItems.id, existingItem.id));
           } else {
             await tx.insert(clothingItems).values({
               name: row.itemEn,
               nameAr: row.itemAr,
+              imageUrl: row.imageUrl,
               categoryId: clothingCategoryId,
               userId: user.id,
             });

--- a/server/utils.excel.test.ts
+++ b/server/utils.excel.test.ts
@@ -17,8 +17,9 @@ test('generateCatalogTemplate returns template with headers and example row', ()
     'Urgent Iron',
     'Urgent Wash',
     'Urgent Wash & Iron',
+    'Picture Link',
   ];
-  const exampleRow = ['T-Shirt', 'تي شيرت', 5, 10, 15, 8, 12, 18];
+  const exampleRow = ['T-Shirt', 'تي شيرت', 5, 10, 15, 8, 12, 18, 'https://example.com/image.jpg'];
   assert.deepEqual(rows[0], headers);
   assert.deepEqual(rows[1], exampleRow);
 });

--- a/server/utils/excel.ts
+++ b/server/utils/excel.ts
@@ -10,6 +10,7 @@ export function generateCatalogTemplate(): Buffer {
     "Urgent Iron",
     "Urgent Wash",
     "Urgent Wash & Iron",
+    "Picture Link",
   ];
 
   const exampleRow = [
@@ -21,6 +22,7 @@ export function generateCatalogTemplate(): Buffer {
     8,
     12,
     18,
+    "https://example.com/image.jpg",
   ];
 
   const wb = XLSX.utils.book_new();


### PR DESCRIPTION
## Summary
- include Picture Link column in catalog template
- parse imageUrl from bulk upload and store on clothing items

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68924635675c832381e161b33f868980