### PR TITLE
Validate laundry service category type

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -563,10 +563,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const validatedData = insertLaundryServiceSchema.parse(req.body);
       const userId = (req.user as UserWithBranch).id;
+      const category = await storage.getCategory(validatedData.categoryId, userId);
+      if (!category || category.type !== "service") {
+        return res.status(400).json({ message: "Invalid category" });
+      }
       const newService = await storage.createLaundryService({ ...validatedData, userId });
       res.json(newService);
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error creating laundry service:", error);
+      if (error?.code === "23503") {
+        return res.status(400).json({ message: "Invalid category" });
+      }
       res.status(500).json({ message: "Failed to create laundry service" });
     }
   });


### PR DESCRIPTION
## Summary
- ensure `/api/laundry-services` checks that referenced category exists and is of type `service`
- return 400 for missing or non-service categories before creation
- add defensive handling of FK errors similar to clothing item validation

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6892796db4a8832391953849e099c76e