### PR TITLE
Map seeded clothing items and services to actual category IDs

### DIFF
--- a/server/seed-data.ts
+++ b/server/seed-data.ts
@@ -1,4 +1,8 @@
-import { type InsertCategory, type InsertClothingItem } from "@shared/schema";
+import {
+  type InsertCategory,
+  type InsertClothingItem,
+  type InsertLaundryService,
+} from "@shared/schema";
 
 export const CATEGORY_SEEDS: Omit<InsertCategory, "userId">[] = [
   { name: "Normal Iron", nameAr: "كي عادي", type: "service", isActive: true },
@@ -10,9 +14,33 @@ export const CATEGORY_SEEDS: Omit<InsertCategory, "userId">[] = [
   { name: "Clothing Items", nameAr: "ملابس", type: "clothing", isActive: true },
 ];
 
-export const CLOTHING_ITEM_SEEDS: Omit<InsertClothingItem, "categoryId" | "userId">[] = [
+export const CLOTHING_ITEM_SEEDS: Omit<
+  InsertClothingItem,
+  "categoryId" | "userId"
+>[] = [
   { name: "Thobe", nameAr: "ثوب" },
   { name: "Shirt", nameAr: "قميص" },
   { name: "T-Shirt", nameAr: "تيشيرت" },
   { name: "Trouser", nameAr: "بنطال" },
 ];
+
+export function mapClothingItemSeeds(
+  categoryIds: Record<string, string>,
+): Omit<InsertClothingItem, "userId">[] {
+  const clothingCategory = CATEGORY_SEEDS.find((c) => c.type === "clothing")!;
+  return CLOTHING_ITEM_SEEDS.map((item) => ({
+    ...item,
+    categoryId: categoryIds[clothingCategory.name],
+  }));
+}
+
+export function mapLaundryServiceSeeds(
+  categoryIds: Record<string, string>,
+): Omit<InsertLaundryService, "userId">[] {
+  return CATEGORY_SEEDS.filter((c) => c.type === "service").map((c) => ({
+    name: c.name,
+    nameAr: c.nameAr,
+    price: "0.00",
+    categoryId: categoryIds[c.name],
+  }));
+}


### PR DESCRIPTION
## Summary
- map clothing and laundry-service seeds to real category IDs
- seed user catalog using generated category IDs instead of hard-coded strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68927d349c148323bb0dd568e2412309