### PR TITLE
Seed superadmin account

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage, type ParsedRow } from "./storage";
 import { insertTransactionSchema, insertClothingItemSchema, insertLaundryServiceSchema, insertProductSchema, insertUserSchema, updateUserSchema, insertCategorySchema, insertBranchSchema, insertCustomerSchema, insertOrderSchema, insertPaymentSchema, insertSecuritySettingsSchema, insertItemServicePriceSchema } from "@shared/schema";
 import { setupAuth, requireAuth, requireSuperAdmin, requireAdminOrSuperAdmin } from "./auth";
+import { seedSuperAdmin } from "./seed-superadmin";
 import passport from "passport";
 import type { UserWithBranch } from "@shared/schema";
 import nodemailer from "nodemailer";
@@ -15,6 +16,7 @@ const upload = multer();
 export async function registerRoutes(app: Express): Promise<Server> {
   // Setup authentication
   await setupAuth(app);
+  await seedSuperAdmin();
 
   // Authentication routes
   app.post("/api/login", (req, res, next) => {

--- a/server/seed-superadmin.ts
+++ b/server/seed-superadmin.ts
@@ -1,0 +1,20 @@
+import bcrypt from "bcryptjs";
+import { storage } from "./storage";
+
+export async function seedSuperAdmin() {
+  const existing = await storage.getUser("superadmin");
+  if (!existing) {
+    const passwordHash = await bcrypt.hash("admin123", 10);
+    await storage.upsertUser({
+      id: "superadmin",
+      username: "superadmin",
+      email: null,
+      passwordHash,
+      firstName: "Super",
+      lastName: "Admin",
+      role: "super_admin",
+      isActive: true,
+      branchId: null,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- seed a `superadmin` user with a bcrypt hashed password when the server starts
- run the seeding step during route registration to ensure admin actions use a valid user id

## Testing
- `npm run db:push`
- `npm test`
- `npm run check`
- Verified SQL insert succeeds when `user_id='superadmin'` and fails for nonexistent users

------
https://chatgpt.com/codex/tasks/task_e_68928599294c83239428bd2d3fb7fa20