### PR TITLE
Check superadmin seeding by username

### DIFF
--- a/server/seed-superadmin.ts
+++ b/server/seed-superadmin.ts
@@ -2,19 +2,19 @@ import bcrypt from "bcryptjs";
 import { storage } from "./storage";
 
 export async function seedSuperAdmin() {
-  const existing = await storage.getUser("superadmin");
-  if (!existing) {
-    const passwordHash = await bcrypt.hash("admin123", 10);
-    await storage.upsertUser({
-      id: "superadmin",
-      username: "superadmin",
-      email: null,
-      passwordHash,
-      firstName: "Super",
-      lastName: "Admin",
-      role: "super_admin",
-      isActive: true,
-      branchId: null,
-    });
-  }
+  const existing = await storage.getUserByUsername("superadmin");
+  if (existing) return;
+
+  const passwordHash = await bcrypt.hash("admin123", 10);
+  await storage.upsertUser({
+    id: "superadmin",
+    username: "superadmin",
+    email: null,
+    passwordHash,
+    firstName: "Super",
+    lastName: "Admin",
+    role: "super_admin",
+    isActive: true,
+    branchId: null,
+  });
 }


### PR DESCRIPTION
## Summary
- ensure super admin seeding checks for existing username and exits early

## Testing
- `npm test`
- `npm run check`
- `psql "$DATABASE_URL" -c "DELETE FROM users WHERE username='superadmin' AND id <> 'superadmin';"` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689308c02e1c8323bffc4fb6af3c0628