### PR TITLE
Show service category names in selection modal

### DIFF
--- a/client/src/components/service-selection-modal.tsx
+++ b/client/src/components/service-selection-modal.tsx
@@ -151,6 +151,9 @@ export function ServiceSelectionModal({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {services.map((service) => {
             const isSelected = selectedServiceId === service.id;
+            const category = serviceCategories.find(
+              (c) => c.id === service.categoryId,
+            );
             return (
               <Card
                 key={service.id}
@@ -175,7 +178,9 @@ export function ServiceSelectionModal({
                       {formatCurrency(service.itemPrice)}
                     </span>
                     <span className="text-xs text-gray-500 capitalize bg-gray-100 px-2 py-1 rounded">
-                      {service.categoryId}
+                      {language === "ar" && category?.nameAr
+                        ? category.nameAr
+                        : category?.name || service.categoryId}
                     </span>
                   </div>
 


### PR DESCRIPTION
## Summary
- display human-readable category names in service selection cards

## Testing
- `npm test`
- `npm run check` *(fails: Type 'MapIterator<...>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher)*

------
https://chatgpt.com/codex/tasks/task_e_689345b7da68832396621f83e6bd738c