### PR TITLE
Use plain strings for order item references

### DIFF
--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -289,28 +289,34 @@ export function ReceiptModal({ transaction, order, customer, isOpen, onClose }: 
 
           {/* Items */}
           <div className="space-y-2">
-            {items.map((item, index) => (
-              <div key={index} className="space-y-1">
-                <div className="flex">
-                  <div className="flex-1 flex justify-between">
-                    <span className="flex-1">{item.name || item.clothingItem}</span>
-                    <span>{formatCurrency(item.total)}</span>
+            {items.map((item, index) => {
+              const serviceName =
+                typeof item.service === "string"
+                  ? item.service
+                  : item.service?.name || "";
+              return (
+                <div key={index} className="space-y-1">
+                  <div className="flex">
+                    <div className="flex-1 flex justify-between">
+                      <span className="flex-1">{item.name || item.clothingItem}</span>
+                      <span>{formatCurrency(item.total)}</span>
+                    </div>
+                    <div className="flex-1 flex justify-between text-right" dir="rtl">
+                      <span className="flex-1">{item.name || item.clothingItem}</span>
+                      <span>{formatCurrency(item.total)}</span>
+                    </div>
                   </div>
-                  <div className="flex-1 flex justify-between text-right" dir="rtl">
-                    <span className="flex-1">{item.name || item.clothingItem}</span>
-                    <span>{formatCurrency(item.total)}</span>
+                  <div className="flex">
+                    <span className="text-xs text-gray-600 flex-1 pl-2">
+                      {serviceName} × {item.quantity}
+                    </span>
+                    <span className="text-xs text-gray-600 flex-1 text-right" dir="rtl">
+                      {serviceName} × {item.quantity}
+                    </span>
                   </div>
                 </div>
-                <div className="flex">
-                  <span className="text-xs text-gray-600 flex-1 pl-2">
-                    {item.service} × {item.quantity}
-                  </span>
-                  <span className="text-xs text-gray-600 flex-1 text-right" dir="rtl">
-                    {item.service} × {item.quantity}
-                  </span>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="border-t border-gray-400 pt-3 space-y-1">

--- a/client/src/components/reports-dashboard.tsx
+++ b/client/src/components/reports-dashboard.tsx
@@ -43,7 +43,10 @@ export function ReportsDashboard() {
   const serviceBreakdown = filteredTransactions.reduce((acc, transaction) => {
     const items = transaction.items as any[];
     items.forEach(item => {
-      const serviceName = item.service || "Unknown Service";
+      const serviceName =
+        typeof item.service === "string"
+          ? item.service
+          : item.service?.name || "Unknown Service";
       if (!acc[serviceName]) {
         acc[serviceName] = { count: 0, revenue: 0 };
       }

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -152,8 +152,8 @@ export default function POS() {
     const orderItems = cartSummary.items.map(item => ({
       id: item.id,
       name: item.clothingItem.name,
-      clothingItem: { name: item.clothingItem.name },
-      service: { name: item.service.name },
+      clothingItem: item.clothingItem.name,
+      service: item.service.name,
       quantity: item.quantity,
       price: parseFloat(item.service.price),
       total: item.total


### PR DESCRIPTION
## Summary
- Simplify order item payload by sending clothing item and service names as plain strings
- Show service names in receipts regardless of whether stored as string or object
- Improve reports dashboard service breakdown to handle both string and object formats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689393a6acbc83238cb178d90761592e