### PR TITLE
Show localized item name in clothing grid

### DIFF
--- a/client/src/components/clothing-grid.tsx
+++ b/client/src/components/clothing-grid.tsx
@@ -119,7 +119,7 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
                   )}
                   <div className="text-center">
                     <span className="text-sm text-gray-500 capitalize">
-                      {item.categoryId}
+                      {language === 'ar' && item.nameAr ? item.nameAr : item.name}
                     </span>
                   </div>
                   <TooltipProvider>


### PR DESCRIPTION
## Summary
- Display Arabic item name when available in clothing grid details span instead of category id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a4599cfc8323a7ec808b8e4fbfbb