### PR TITLE
feat: add customer nickname

### DIFF
--- a/client/src/components/customer-management.tsx
+++ b/client/src/components/customer-management.tsx
@@ -31,6 +31,7 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
     name: "",
     email: "",
     address: "",
+    nickname: "",
   });
   const [paymentAmount, setPaymentAmount] = useState("");
   const [paymentMethod, setPaymentMethod] = useState("cash");
@@ -78,7 +79,7 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
       });
       queryClient.invalidateQueries({ queryKey: ["/api/customers"] });
       setIsAddDialogOpen(false);
-      setNewCustomer({ phoneNumber: "", name: "", email: "", address: "" });
+      setNewCustomer({ phoneNumber: "", name: "", email: "", address: "", nickname: "" });
     },
     onError: () => {
       toast({
@@ -116,6 +117,7 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
 
   const filteredCustomers = customers.filter(customer =>
     customer.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    customer.nickname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
     customer.phoneNumber.includes(searchTerm) ||
     customer.email?.toLowerCase().includes(searchTerm.toLowerCase())
   );
@@ -129,7 +131,8 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
       });
       return;
     }
-    addCustomerMutation.mutate(newCustomer);
+    const data = { ...newCustomer, nickname: newCustomer.nickname || undefined };
+    addCustomerMutation.mutate(data);
   };
 
   const handleRecordPayment = () => {
@@ -225,6 +228,15 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
                 />
               </div>
               <div>
+                <Label htmlFor="nickname">Nickname</Label>
+                <Input
+                  id="nickname"
+                  value={newCustomer.nickname || ""}
+                  onChange={(e) => setNewCustomer({ ...newCustomer, nickname: e.target.value })}
+                  placeholder="Enter nickname"
+                />
+              </div>
+              <div>
                 <Label htmlFor="email">Email</Label>
                 <Input
                   id="email"
@@ -259,7 +271,7 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
       <div className="relative">
         <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
         <Input
-          placeholder="Search customers by name, phone, or email..."
+          placeholder="Search customers by name, nickname, phone, or email..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="pl-10"
@@ -272,7 +284,14 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
             <CardHeader className="pb-3">
               <div className="flex justify-between items-start">
                 <div>
-                  <CardTitle className="text-lg">{customer.name}</CardTitle>
+                  <CardTitle className="text-lg">
+                    {customer.name}
+                    {customer.nickname && (
+                      <span className="text-sm text-gray-500 ml-2">
+                        ({customer.nickname})
+                      </span>
+                    )}
+                  </CardTitle>
                   <CardDescription className="flex items-center mt-1">
                     <Phone className="w-3 h-3 mr-1" />
                     {customer.phoneNumber}

--- a/client/src/components/laundry-cart-sidebar.tsx
+++ b/client/src/components/laundry-cart-sidebar.tsx
@@ -58,6 +58,7 @@ export function LaundryCartSidebar({
     name: "",
     email: "",
     address: "",
+    nickname: "",
   });
   const [redeemPoints, setRedeemPoints] = useState(0);
 
@@ -87,7 +88,7 @@ export function LaundryCartSidebar({
       queryClient.invalidateQueries({ queryKey: ["/api/customers"] });
       onSelectCustomer(customer);
       setIsCustomerDialogOpen(false);
-      setNewCustomer({ phoneNumber: "", name: "", email: "", address: "" });
+      setNewCustomer({ phoneNumber: "", name: "", email: "", address: "", nickname: "" });
     },
     onError: () => {
       toast({
@@ -100,6 +101,7 @@ export function LaundryCartSidebar({
 
   const filteredCustomers = customers.filter(customer =>
     customer.name.toLowerCase().includes(customerSearch.toLowerCase()) ||
+    customer.nickname?.toLowerCase().includes(customerSearch.toLowerCase()) ||
     customer.phoneNumber.includes(customerSearch)
   );
 
@@ -112,7 +114,8 @@ export function LaundryCartSidebar({
       });
       return;
     }
-    addCustomerMutation.mutate(newCustomer);
+    const data = { ...newCustomer, nickname: newCustomer.nickname || undefined };
+    addCustomerMutation.mutate(data);
   };
 
   return (
@@ -143,7 +146,14 @@ export function LaundryCartSidebar({
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4 text-gray-500" />
                 <div>
-                  <p className="font-medium">{selectedCustomer.name}</p>
+                  <p className="font-medium">
+                    {selectedCustomer.name}
+                    {selectedCustomer.nickname && (
+                      <span className="text-sm text-gray-500 ml-1">
+                        ({selectedCustomer.nickname})
+                      </span>
+                    )}
+                  </p>
                   <p className="text-sm text-gray-500">{selectedCustomer.phoneNumber}</p>
                   {parseFloat(selectedCustomer.balanceDue) > 0 && (
                     <Badge variant="destructive" className="text-xs">
@@ -178,7 +188,7 @@ export function LaundryCartSidebar({
                 
                 <div className="space-y-4">
                   <Input
-                    placeholder="Search customers by name or phone..."
+                    placeholder="Search customers by name, nickname, or phone..."
                     value={customerSearch}
                     onChange={(e) => setCustomerSearch(e.target.value)}
                   />
@@ -194,7 +204,14 @@ export function LaundryCartSidebar({
                         }}
                       >
                         <div>
-                          <p className="font-medium">{customer.name}</p>
+                          <p className="font-medium">
+                            {customer.name}
+                            {customer.nickname && (
+                              <span className="text-sm text-gray-500 ml-1">
+                                ({customer.nickname})
+                              </span>
+                            )}
+                          </p>
                           <p className="text-sm text-gray-500">{customer.phoneNumber}</p>
                         </div>
                         {parseFloat(customer.balanceDue) > 0 && (
@@ -227,6 +244,15 @@ export function LaundryCartSidebar({
                           value={newCustomer.name}
                           onChange={(e) => setNewCustomer({ ...newCustomer, name: e.target.value })}
                           placeholder="Customer name"
+                        />
+                      </div>
+                      <div className="col-span-2">
+                        <Label htmlFor="nickname">Nickname</Label>
+                        <Input
+                          id="nickname"
+                          value={newCustomer.nickname || ""}
+                          onChange={(e) => setNewCustomer({ ...newCustomer, nickname: e.target.value })}
+                          placeholder="Nickname"
                         />
                       </div>
                     </div>

--- a/migrations/0004_add_nickname_to_customers.sql
+++ b/migrations/0004_add_nickname_to_customers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "customers" ADD COLUMN "nickname" text;
+ALTER TABLE "customers" ADD CONSTRAINT "customers_nickname_unique" UNIQUE("nickname");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -793,6 +793,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/customers/nickname/:nickname", requireAuth, async (req, res) => {
+    try {
+      const customer = await storage.getCustomerByNickname(req.params.nickname);
+      if (!customer) {
+        return res.status(404).json({ message: "Customer not found" });
+      }
+      res.json(customer);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch customer" });
+    }
+  });
+
   app.post("/api/customers", requireAuth, async (req, res) => {
     try {
       const customerData = insertCustomerSchema.parse(req.body);
@@ -805,7 +817,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.patch("/api/customers/:id", requireAuth, async (req, res) => {
     try {
-      const customer = await storage.updateCustomer(req.params.id, req.body);
+      const data = insertCustomerSchema.partial().parse(req.body);
+      const customer = await storage.updateCustomer(req.params.id, data);
       if (!customer) {
         return res.status(404).json({ message: "Customer not found" });
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -137,6 +137,7 @@ export interface IStorage {
   getCustomers(): Promise<Customer[]>;
   getCustomer(id: string): Promise<Customer | undefined>;
   getCustomerByPhone(phoneNumber: string): Promise<Customer | undefined>;
+  getCustomerByNickname(nickname: string): Promise<Customer | undefined>;
   createCustomer(customer: InsertCustomer): Promise<Customer>;
   updateCustomer(id: string, customer: Partial<InsertCustomer>): Promise<Customer | undefined>;
   updateCustomerBalance(id: string, balanceChange: number): Promise<Customer | undefined>;
@@ -1390,6 +1391,11 @@ export class DatabaseStorage implements IStorage {
 
   async getCustomerByPhone(phoneNumber: string): Promise<Customer | undefined> {
     const [customer] = await db.select().from(customers).where(eq(customers.phoneNumber, phoneNumber));
+    return customer || undefined;
+  }
+
+  async getCustomerByNickname(nickname: string): Promise<Customer | undefined> {
+    const [customer] = await db.select().from(customers).where(eq(customers.nickname, nickname));
     return customer || undefined;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -118,6 +118,7 @@ export const customers = pgTable("customers", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   phoneNumber: varchar("phone_number", { length: 20 }).unique().notNull(),
   name: text("name").notNull(),
+  nickname: text("nickname").unique(),
   email: varchar("email", { length: 255 }),
   address: text("address"),
   balanceDue: decimal("balance_due", { precision: 10, scale: 2 }).default("0.00").notNull(),


### PR DESCRIPTION
## Summary
- add optional unique `nickname` to customer schema and database
- expose nickname through API and allow searching by nickname
- support nickname entry and filtering in customer management and POS flows

## Testing
- `npm test`
- `npm run check` *(fails: Argument of type 'readonly [...]' is not assignable to parameter of type 'string[]')*

------
https://chatgpt.com/codex/tasks/task_e_6893c7fba2308323923d46f48718d5f2