### PR TITLE
fix upsertUser conflict target

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -789,7 +789,7 @@ export class DatabaseStorage implements IStorage {
       .insert(users)
       .values(userData)
       .onConflictDoUpdate({
-        target: [users.id, users.username],
+        target: users.username,
         set: {
           ...userData,
           updatedAt: new Date(),


### PR DESCRIPTION
## Summary
- correct upsertUser to use a single username conflict target

## Testing
- `npm test`
- `npm run db:push` *(fails: connect ENETUNREACH 72.144.105.10:5432)*

------
https://chatgpt.com/codex/tasks/task_e_6894af1f62f883239cd11f9a24fc66ae