### PR TITLE
feat: nest payment creation under customers

### DIFF
--- a/client/src/components/customer-management.tsx
+++ b/client/src/components/customer-management.tsx
@@ -159,7 +159,12 @@ export function CustomerManagement({ onCustomerSelect }: CustomerManagementProps
 
   const recordPaymentMutation = useMutation({
     mutationFn: async (payment: InsertPayment) => {
-      const response = await apiRequest("POST", "/api/payments", payment);
+      const { customerId, ...data } = payment;
+      const response = await apiRequest(
+        "POST",
+        `/api/customers/${customerId}/payments`,
+        data
+      );
       return response.json();
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- add POST /api/customers/:customerId/payments for creating payments per customer
- deprecate POST /api/payments and route requests through new handler
- update client to send payments to nested customer endpoint

## Testing
- `npm test`
- `npm run check` *(fails: Type 'Date' is not assignable to type 'string' and other existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895f566a86c8323a45936876398a8bf