### PR TITLE
Add OrderItem type and summary tests

### DIFF
--- a/client/src/components/order-tracking.test.ts
+++ b/client/src/components/order-tracking.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getItemsSummary, OrderItem } from './order-tracking';
+
+describe('getItemsSummary', () => {
+  it('formats items with string values', () => {
+    const items: OrderItem[] = [
+      { clothingItem: 'Shirt', service: 'Wash', quantity: 2 },
+      { clothingItem: 'Pants', service: 'Dry', quantity: 1 },
+    ];
+    expect(getItemsSummary(items)).toBe('2x Shirt (Wash), 1x Pants (Dry)');
+  });
+
+  it('formats items with object values', () => {
+    const items: OrderItem[] = [
+      { clothingItem: { name: 'Jacket' }, service: { name: 'Dry Clean' }, quantity: 3 },
+    ];
+    expect(getItemsSummary(items)).toBe('3x Jacket (Dry Clean)');
+  });
+});

--- a/client/src/components/order-tracking.tsx
+++ b/client/src/components/order-tracking.tsx
@@ -14,6 +14,12 @@ import { format } from "date-fns";
 import { useCurrency } from "@/lib/currency";
 import { ReceiptModal } from "./receipt-modal";
 
+export interface OrderItem {
+  clothingItem: string | { name: string };
+  service: string | { name: string };
+  quantity: number;
+}
+
 const statusColors = {
   received: "bg-blue-100 text-blue-800",
   processing: "bg-yellow-100 text-yellow-800", 
@@ -30,6 +36,22 @@ const statusIcons = {
   drying: Clock,
   ready: CheckCircle,
   completed: CheckCircle,
+};
+
+export const getItemsSummary = (items: OrderItem[]): string => {
+  return items
+    .map((item) => {
+      const clothingName =
+        typeof item.clothingItem === "string"
+          ? item.clothingItem
+          : item.clothingItem?.name || "Item";
+      const serviceName =
+        typeof item.service === "string"
+          ? item.service
+          : item.service?.name || "Service";
+      return `${item.quantity}x ${clothingName} (${serviceName})`;
+    })
+    .join(", ");
 };
 
 export function OrderTracking() {
@@ -101,18 +123,6 @@ export function OrderTracking() {
     }
   };
 
-  const getItemsSummary = (items: any[]) => {
-    return items.map(item => {
-      const clothingName = typeof item.clothingItem === 'string'
-        ? item.clothingItem
-        : item.clothingItem?.name || 'Item';
-      const serviceName = typeof item.service === 'string'
-        ? item.service
-        : item.service?.name || 'Service';
-      return `${item.quantity}x ${clothingName} (${serviceName})`;
-    }).join(", ");
-  };
-
   if (isLoading) {
     return <div className="p-4">Loading orders...</div>;
   }
@@ -172,7 +182,9 @@ export function OrderTracking() {
         <div className="space-y-4">
         {filteredOrders.map((order) => {
           const StatusIcon = statusIcons[order.status as keyof typeof statusIcons];
-          const items = Array.isArray(order.items) ? order.items : [];
+          const items: OrderItem[] = Array.isArray(order.items)
+            ? (order.items as OrderItem[])
+            : [];
           
           return (
             <Card key={order.id} className="hover:shadow-md transition-shadow">

--- a/client/src/components/receipt-modal.tsx
+++ b/client/src/components/receipt-modal.tsx
@@ -19,7 +19,7 @@ interface ReceiptModalProps {
   isOpen: boolean;
   onClose: () => void;
   printNumber?: number;
-  printedAt?: string;
+  printedAt?: string | Date;
 }
 
 export function ReceiptModal({ transaction, order, customer, isOpen, onClose, printNumber, printedAt }: ReceiptModalProps) {


### PR DESCRIPTION
## Summary
- add `OrderItem` interface and typed `getItemsSummary`
- update ReceiptModal to accept Date for `printedAt`
- introduce unit tests covering item summary formatting

## Testing
- `npm test`
- `npm run check` *(fails: server TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68965ed7c5488323b575c74b15b21e02