### PR TITLE
feat: fetch product categories

### DIFF
--- a/client/src/components/product-grid.test.tsx
+++ b/client/src/components/product-grid.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, vi, expect, afterEach } from "vitest";
+import { ProductGrid } from "./product-grid";
+
+const matchMediaMock = vi.fn().mockReturnValue({
+  matches: false,
+  media: "",
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
+// @ts-ignore
+window.matchMedia = matchMediaMock as any;
+
+function renderWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProductGrid onAddToCart={() => {}} cartItemCount={0} onToggleCart={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+const originalFetch = global.fetch;
+
+describe("ProductGrid", () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    matchMediaMock.mockClear();
+  });
+
+  it("renders fetched categories", async () => {
+    const mockCategories = [
+      { id: "c1", name: "Cat 1" },
+      { id: "c2", name: "Cat 2" },
+    ];
+
+    global.fetch = vi.fn((url: RequestInfo) => {
+      if (typeof url === "string" && url.startsWith("/api/product-categories")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockCategories), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (typeof url === "string" && url.startsWith("/api/products")) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error("Unknown URL"));
+    }) as any;
+
+    renderWithClient();
+
+    await waitFor(() => {
+      expect(screen.getByText("Cat 1")).toBeTruthy();
+      expect(screen.getByText("Cat 2")).toBeTruthy();
+    });
+  });
+
+  it("shows error state when categories fail to load", async () => {
+    global.fetch = vi.fn((url: RequestInfo) => {
+      if (typeof url === "string" && url.startsWith("/api/product-categories")) {
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      if (typeof url === "string" && url.startsWith("/api/products")) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.reject(new Error("Unknown URL"));
+    }) as any;
+
+    renderWithClient();
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load categories")).toBeTruthy();
+    });
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -448,6 +448,16 @@ export async function registerRoutes(
     }
   });
 
+  app.get("/api/product-categories", requireAuth, async (req, res) => {
+    try {
+      const userId = (req.user as UserWithBranch).id;
+      const categories = await storage.getCategoriesByType("product", userId);
+      res.json(categories);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch product categories" });
+    }
+  });
+
   app.post("/api/products", requireAdminOrSuperAdmin, async (req, res) => {
     try {
       const user = req.user as UserWithBranch;


### PR DESCRIPTION
## Summary
- add server endpoint to serve product categories
- load product categories in ProductGrid via `useQuery`
- test ProductGrid category fetching with mocked requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966454c1f8832389dabf3335c343f9