### PR TITLE
Require explicit session secret and secure cookies

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -22,6 +22,11 @@ const hardcodedAdmin: User = {
   updatedAt: new Date(),
 };
 
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  throw new Error("SESSION_SECRET environment variable is required");
+}
+
 export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const pgStore = connectPg(session);
@@ -31,8 +36,7 @@ export function getSession() {
     ttl: sessionTtl,
     tableName: "sessions",
   });
-  const sessionSecret = process.env.SESSION_SECRET || 'fallback-secret-for-development';
-  
+
   return session({
     secret: sessionSecret,
     store: sessionStore,
@@ -40,7 +44,8 @@ export function getSession() {
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: false, // Set to true in production with HTTPS
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
       maxAge: sessionTtl,
     },
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,13 +5,8 @@ import { setupVite, serveStatic, log } from "./vite";
 import logger from "./logger";
 import { NotificationService } from "./services/notification";
 
-// Set SESSION_SECRET if not present
 if (!process.env.SESSION_SECRET) {
-  process.env.SESSION_SECRET = 'laundry-system-secret-key-' + Date.now();
-  logger.warn(
-    'SESSION_SECRET was not set, generated fallback:',
-    process.env.SESSION_SECRET.substring(0, 20) + '...',
-  );
+  throw new Error("SESSION_SECRET environment variable is required");
 }
 
 const app = express();

--- a/server/routes.auth.test.ts
+++ b/server/routes.auth.test.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 
 // Ensure DATABASE_URL is set to allow importing auth module without DB
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost/db';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
 
 const { requireAdminOrSuperAdmin, requireAuth } = await import('./auth');
 

--- a/server/routes.clothing-items.test.ts
+++ b/server/routes.clothing-items.test.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import request from 'supertest';
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost/db';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
 
 const { requireAdminOrSuperAdmin } = await import('./auth');
 import { insertClothingItemSchema } from '@shared/schema';

--- a/server/routes.transactions.test.ts
+++ b/server/routes.transactions.test.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 import { insertTransactionSchema } from '@shared/schema';
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost/db';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
 const { requireAuth } = await import('./auth');
 
 function createApp(storage: any) {

--- a/server/routes.user.test.ts
+++ b/server/routes.user.test.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import request from 'supertest';
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost/db';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
 
 const { requireSuperAdmin } = await import('./auth');
 const { storage } = await import('./storage');


### PR DESCRIPTION
## Summary
- Ensure session middleware requires a `SESSION_SECRET` and uses secure, `sameSite: 'lax'` cookies
- Fail fast at server startup if `SESSION_SECRET` is missing
- Set `SESSION_SECRET` in server route tests for module imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689666aa48fc8323b7b7829db8f5927a