### PR TITLE
Add delivery roles and delivery account mapping

### DIFF
--- a/client/src/components/admin/UserManager.tsx
+++ b/client/src/components/admin/UserManager.tsx
@@ -157,6 +157,12 @@ export function UserManager() {
         return <Badge variant="destructive">Super Admin</Badge>;
       case 'admin':
         return <Badge variant="default">Admin</Badge>;
+      case 'delivery_admin':
+        return <Badge variant="default">Delivery Admin</Badge>;
+      case 'dispatcher':
+        return <Badge variant="secondary">Dispatcher</Badge>;
+      case 'driver':
+        return <Badge variant="secondary">Driver</Badge>;
       default:
         return <Badge variant="secondary">User</Badge>;
     }
@@ -263,6 +269,9 @@ export function UserManager() {
                       <SelectItem value="user">User</SelectItem>
                       <SelectItem value="admin">Admin</SelectItem>
                       <SelectItem value="super_admin">Super Admin</SelectItem>
+                      <SelectItem value="delivery_admin">Delivery Admin</SelectItem>
+                      <SelectItem value="dispatcher">Dispatcher</SelectItem>
+                      <SelectItem value="driver">Driver</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/client/src/components/pos-header.tsx
+++ b/client/src/components/pos-header.tsx
@@ -78,10 +78,13 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
             <LanguageSelector />
             
             {/* Admin Access */}
-            {user && (user.role === 'admin' || user.role === 'super_admin') && (
+            {user &&
+              (user.role === 'admin' ||
+                user.role === 'super_admin' ||
+                user.role === 'delivery_admin') && (
               <Link href="/admin">
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   className="p-2 hover:bg-blue-700 text-white hover:text-white flex items-center space-x-2"
                 >

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -12,6 +12,9 @@ interface AuthContextValue {
   isAuthenticated: boolean;
   isAdmin: boolean;
   isSuperAdmin: boolean;
+  isDeliveryAdmin: boolean;
+  isDispatcher: boolean;
+  isDriver: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -29,8 +32,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     branch: user?.branch || null,
     isLoading,
     isAuthenticated: !!user && !error,
-    isAdmin: user?.role === "admin" || user?.role === "super_admin",
+    isAdmin:
+      user?.role === "admin" ||
+      user?.role === "super_admin" ||
+      user?.role === "delivery_admin",
     isSuperAdmin: user?.role === "super_admin",
+    isDeliveryAdmin: user?.role === "delivery_admin",
+    isDispatcher: user?.role === "dispatcher",
+    isDriver: user?.role === "driver",
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -18,6 +18,7 @@ const hardcodedAdmin: User = {
   role: "super_admin",
   isActive: true,
   branchId: null,
+  deliveryAccountId: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -125,4 +126,25 @@ export const requireAdminOrSuperAdmin: RequestHandler = (req, res, next) => {
     return next();
   }
   res.status(403).json({ message: "Admin access required" });
+};
+
+export const requireDeliveryAdmin: RequestHandler = (req, res, next) => {
+  if (req.isAuthenticated() && (req.user as User)?.role === 'delivery_admin') {
+    return next();
+  }
+  res.status(403).json({ message: "Delivery admin access required" });
+};
+
+export const requireDispatcher: RequestHandler = (req, res, next) => {
+  if (req.isAuthenticated() && (req.user as User)?.role === 'dispatcher') {
+    return next();
+  }
+  res.status(403).json({ message: "Dispatcher access required" });
+};
+
+export const requireDriver: RequestHandler = (req, res, next) => {
+  if (req.isAuthenticated() && (req.user as User)?.role === 'driver') {
+    return next();
+  }
+  res.status(403).json({ message: "Driver access required" });
 };

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -15,6 +15,7 @@ const baseUser = {
   email: 'test@example.com',
   role: 'user',
   branchId: null,
+  deliveryAccountId: null,
   passwordHash: 'existing-hash',
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -72,7 +72,8 @@ export const users = pgTable("users", {
   firstName: varchar("first_name", { length: 100 }),
   lastName: varchar("last_name", { length: 100 }),
   branchId: varchar("branch_id").references(() => branches.id),
-  role: text("role").notNull().default('user'), // 'super_admin', 'admin', 'user'
+  deliveryAccountId: varchar("delivery_account_id").references(() => users.id),
+  role: text("role").notNull().default('user'), // 'super_admin', 'admin', 'user', 'delivery_admin', 'dispatcher', 'driver'
   isActive: boolean("is_active").default(true).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
@@ -103,6 +104,19 @@ export const branches = pgTable("branches", {
   code: varchar("code", { length: 3 }).unique().notNull(),
   nextOrderNumber: integer("next_order_number").notNull().default(1),
 });
+
+export const deliveryAccountBranches = pgTable(
+  "delivery_account_branches",
+  {
+    deliveryAccountId: varchar("delivery_account_id")
+      .references(() => users.id)
+      .notNull(),
+    branchId: varchar("branch_id").references(() => branches.id).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.deliveryAccountId, table.branchId] }),
+  }),
+);
 
 // Customers table for customer management and pay-later tracking
 export const customers = pgTable("customers", {
@@ -312,6 +326,8 @@ export const insertBranchSchema = createInsertSchema(branches).omit({
   logoUrl: z.string().url().optional(),
 });
 
+export const insertDeliveryAccountBranchSchema = createInsertSchema(deliveryAccountBranches);
+
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type UpdateUser = z.infer<typeof updateUserSchema>;
@@ -330,6 +346,8 @@ export type Category = typeof categories.$inferSelect;
 export type InsertCategory = z.infer<typeof insertCategorySchema>;
 export type Branch = typeof branches.$inferSelect;
 export type InsertBranch = z.infer<typeof insertBranchSchema>;
+export type DeliveryAccountBranch = typeof deliveryAccountBranches.$inferSelect;
+export type InsertDeliveryAccountBranch = z.infer<typeof insertDeliveryAccountBranchSchema>;
 export type Customer = typeof customers.$inferSelect;
 export type InsertCustomer = z.infer<typeof insertCustomerSchema>;
 export type Order = typeof orders.$inferSelect;


### PR DESCRIPTION
## Summary
- expand user schema with delivery roles and self-referential `delivery_account_id`
- map delivery admins to branches via new `delivery_account_branches` table
- support new delivery roles in auth middleware, context and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689750fd972c8323b92ab86b8974a14b