### PR TITLE
feat: add delivery order management

### DIFF
--- a/client/src/components/delivery/DispatcherDashboard.tsx
+++ b/client/src/components/delivery/DispatcherDashboard.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Button } from "../ui/button";
+
+interface DeliveryOrder {
+  orderId: string;
+  driverId: string | null;
+  status: string;
+  order?: { orderNumber: string };
+}
+
+export default function DispatcherDashboard() {
+  const [orders, setOrders] = useState<DeliveryOrder[]>([]);
+
+  const load = async () => {
+    const res = await fetch("/api/delivery/orders");
+    if (res.ok) {
+      setOrders(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const assign = async (orderId: string, driverId: string) => {
+    await fetch("/api/delivery/assign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orderId, driverId }),
+    });
+    await load();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Dispatcher Dashboard</h2>
+      <ul className="space-y-2">
+        {orders.map((o) => (
+          <li key={o.orderId} className="flex items-center gap-2">
+            <span className="flex-1">
+              {o.order?.orderNumber || o.orderId} - {o.status} - {o.driverId || "Unassigned"}
+            </span>
+            <Button
+              onClick={() => {
+                const id = window.prompt("Driver ID");
+                if (id) assign(o.orderId, id);
+              }}
+            >
+              Assign
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/delivery/DriverDashboard.tsx
+++ b/client/src/components/delivery/DriverDashboard.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { Button } from "../ui/button";
+
+interface DeliveryOrder {
+  orderId: string;
+  status: string;
+  order?: { orderNumber: string };
+}
+
+export default function DriverDashboard() {
+  const [orders, setOrders] = useState<DeliveryOrder[]>([]);
+
+  const load = async () => {
+    const res = await fetch("/api/delivery/orders");
+    if (res.ok) {
+      setOrders(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const update = async (orderId: string, status: string) => {
+    await fetch("/api/delivery/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orderId, status }),
+    });
+    await load();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Driver Dashboard</h2>
+      <ul className="space-y-2">
+        {orders.map((o) => (
+          <li key={o.orderId} className="flex items-center gap-2">
+            <span className="flex-1">{o.order?.orderNumber || o.orderId} - {o.status}</span>
+            <Button onClick={() => update(o.orderId, "in_transit")}>In Transit</Button>
+            <Button onClick={() => update(o.orderId, "delivered")}>Delivered</Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -157,6 +157,19 @@ export const orders = pgTable("orders", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+// Delivery orders for tracking dispatch and driver status
+export const deliveryOrders = pgTable("delivery_orders", {
+  orderId: varchar("order_id").references(() => orders.id).primaryKey(),
+  driverId: varchar("driver_id").references(() => users.id),
+  status: text("status").notNull().default("pending"), // 'pending', 'dispatched', 'in_transit', 'delivered'
+  pickupTime: timestamp("pickup_time"),
+  dropoffTime: timestamp("dropoff_time"),
+  pickupLat: decimal("pickup_lat", { precision: 9, scale: 6 }),
+  pickupLng: decimal("pickup_lng", { precision: 9, scale: 6 }),
+  dropoffLat: decimal("dropoff_lat", { precision: 9, scale: 6 }),
+  dropoffLng: decimal("dropoff_lng", { precision: 9, scale: 6 }),
+});
+
 export const orderPrints = pgTable(
   "order_prints",
   {
@@ -268,6 +281,8 @@ export const insertOrderSchema = createInsertSchema(orders)
     actualPickup: z.coerce.date().optional(),
   });
 
+export const insertDeliveryOrderSchema = createInsertSchema(deliveryOrders);
+
 export const insertOrderPrintSchema = createInsertSchema(orderPrints).omit({
   printedAt: true,
 });
@@ -352,6 +367,8 @@ export type Customer = typeof customers.$inferSelect;
 export type InsertCustomer = z.infer<typeof insertCustomerSchema>;
 export type Order = typeof orders.$inferSelect;
 export type InsertOrder = z.infer<typeof insertOrderSchema>;
+export type DeliveryOrder = typeof deliveryOrders.$inferSelect;
+export type InsertDeliveryOrder = z.infer<typeof insertDeliveryOrderSchema>;
 export type OrderPrint = typeof orderPrints.$inferSelect;
 export type InsertOrderPrint = z.infer<typeof insertOrderPrintSchema>;
 export type Payment = typeof payments.$inferSelect;


### PR DESCRIPTION
## Summary
- add `delivery_orders` table for dispatch tracking with driver, status and geolocation
- expose `/api/delivery/*` routes with dispatcher/driver role checks
- create dispatcher and driver dashboards with polling for live updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975323f0d88323b7a061f5e9c39ee1