### PR TITLE
fix: upgrade brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4417,9 +4417,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -122,5 +122,8 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
+  },
+  "overrides": {
+    "brace-expansion": "^2.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- enforce brace-expansion >=2.0.2 via package overrides
- update lockfile

## Testing
- `npm install`
- `npm audit --only=prod`


------
https://chatgpt.com/codex/tasks/task_e_689772233d208323b3a08072eb0c5b7c