### PR TITLE
Add map-based location picker for delivery orders

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1161,6 +1161,8 @@ export async function registerRoutes(
         address: z.string(),
         pickupTime: z.string().optional(),
         dropoffTime: z.string().optional(),
+        lat: z.number().optional(),
+        lng: z.number().optional(),
         items: z.array(
           z.object({
             name: z.string(),
@@ -1194,15 +1196,18 @@ export async function registerRoutes(
         branchId: branch.id,
       });
 
-      const geo = await geocodeAddress(data.address);
+      const coords =
+        typeof data.lat === "number" && typeof data.lng === "number"
+          ? { lat: data.lat, lng: data.lng }
+          : await geocodeAddress(data.address);
 
       await db.insert(deliveryOrders).values({
         orderId: order.id,
         pickupTime: data.pickupTime ? new Date(data.pickupTime) : null,
         dropoffTime: data.dropoffTime ? new Date(data.dropoffTime) : null,
         dropoffAddress: data.address,
-        dropoffLat: geo?.lat,
-        dropoffLng: geo?.lng,
+        dropoffLat: coords?.lat,
+        dropoffLng: coords?.lng,
       });
 
       res.status(201).json({ orderId: order.id });


### PR DESCRIPTION
## Summary
- add maplibre-powered LocationPicker in branch delivery form to capture user coordinates
- send latitude and longitude with delivery order payload and accept them on server

## Testing
- `npm run check` *(fails: Type 'unknown' is not assignable to type 'string' ...)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c4c82c2c8323a9429960f9b5a67e