### PR TITLE
feat: show driver locations on dispatcher map

### DIFF
--- a/client/src/components/delivery/DispatcherDashboard.tsx
+++ b/client/src/components/delivery/DispatcherDashboard.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import maplibregl from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
 import { Button } from "../ui/button";
 
 interface DeliveryOrder {
@@ -8,21 +10,70 @@ interface DeliveryOrder {
   order?: { orderNumber: string };
 }
 
+interface DriverLocation {
+  driverId: string;
+  lat: number;
+  lng: number;
+}
+
 export default function DispatcherDashboard() {
   const [orders, setOrders] = useState<DeliveryOrder[]>([]);
+  const [drivers, setDrivers] = useState<DriverLocation[]>([]);
+  const [selectedDriver, setSelectedDriver] = useState<string | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const markersRef = useRef<maplibregl.Marker[]>([]);
 
-  const load = async () => {
+  const loadOrders = async () => {
     const res = await fetch("/api/delivery/orders");
     if (res.ok) {
       setOrders(await res.json());
     }
   };
 
+  const loadDrivers = async () => {
+    const res = await fetch("/api/delivery/driver-locations");
+    if (res.ok) {
+      setDrivers(await res.json());
+    }
+  };
+
   useEffect(() => {
-    load();
-    const id = setInterval(load, 5000);
-    return () => clearInterval(id);
+    loadOrders();
+    loadDrivers();
+    const orderId = setInterval(loadOrders, 5000);
+    const driverId = setInterval(loadDrivers, 5000);
+    return () => {
+      clearInterval(orderId);
+      clearInterval(driverId);
+    };
   }, []);
+
+  useEffect(() => {
+    if (mapRef.current || !mapContainerRef.current) return;
+    mapRef.current = new maplibregl.Map({
+      container: mapContainerRef.current,
+      style: "https://demotiles.maplibre.org/style.json",
+      center: [0, 0],
+      zoom: 2,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    markersRef.current.forEach((m) => m.remove());
+    markersRef.current = [];
+
+    drivers.forEach((d) => {
+      const marker = new maplibregl.Marker({
+        color: d.driverId === selectedDriver ? "#ef4444" : "#3b82f6",
+      })
+        .setLngLat([d.lng, d.lat])
+        .addTo(mapRef.current!);
+      marker.getElement().addEventListener("click", () => setSelectedDriver(d.driverId));
+      markersRef.current.push(marker);
+    });
+  }, [drivers, selectedDriver]);
 
   const assign = async (orderId: string, driverId: string) => {
     await fetch("/api/delivery/assign", {
@@ -30,12 +81,14 @@ export default function DispatcherDashboard() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ orderId, driverId }),
     });
-    await load();
+    await loadOrders();
   };
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">Dispatcher Dashboard</h2>
+      <div ref={mapContainerRef} className="h-64 w-full" />
+      <div>Selected Driver: {selectedDriver || "None"}</div>
       <ul className="space-y-2">
         {orders.map((o) => (
           <li key={o.orderId} className="flex items-center gap-2">
@@ -43,12 +96,10 @@ export default function DispatcherDashboard() {
               {o.order?.orderNumber || o.orderId} - {o.status} - {o.driverId || "Unassigned"}
             </span>
             <Button
-              onClick={() => {
-                const id = window.prompt("Driver ID");
-                if (id) assign(o.orderId, id);
-              }}
+              disabled={!selectedDriver}
+              onClick={() => selectedDriver && assign(o.orderId, selectedDriver)}
             >
-              Assign
+              Assign Selected Driver
             </Button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- poll driver location API and render markers on dispatcher map
- allow selecting a driver marker to assign an order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c93c055883238cc344958eadf84c