### PR TITLE
Integrate product grid cart into delivery order form

### DIFF
--- a/client/src/components/product-grid.tsx
+++ b/client/src/components/product-grid.tsx
@@ -28,9 +28,10 @@ interface ProductGridProps {
   onAddToCart: (product: Product) => void;
   cartItemCount: number;
   onToggleCart: () => void;
+  branchCode?: string;
 }
 
-export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart }: ProductGridProps) {
+export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCode }: ProductGridProps) {
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
@@ -60,9 +61,10 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart }: Produc
     data: products = [],
     isLoading: productsLoading,
   } = useQuery<Product[]>({
-    queryKey: ["/api/products", selectedCategory, searchQuery],
+    queryKey: ["/api/products", branchCode, selectedCategory, searchQuery],
     queryFn: async () => {
       const params = new URLSearchParams();
+      if (branchCode) params.append("branchCode", branchCode);
       if (selectedCategory !== "all") params.append("categoryId", selectedCategory);
       if (searchQuery) params.append("search", searchQuery);
 


### PR DESCRIPTION
## Summary
- replace free-text item entry with product browsing via `ProductGrid`
- manage cart items using `useCart` with inline summary and quantity controls
- send selected cart items to `/delivery/orders` and filter product fetches by branch

## Testing
- `npm test`
- `npm run check` *(fails: TS2322 etc. in pre-existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6899d06885b88323a4795b0270d73d1a