### PR TITLE
Add driver location tracking endpoint for dispatchers

### DIFF
--- a/client/src/components/delivery/DispatcherDashboard.tsx
+++ b/client/src/components/delivery/DispatcherDashboard.tsx
@@ -14,6 +14,7 @@ interface DriverLocation {
   driverId: string;
   lat: number;
   lng: number;
+  timestamp: string;
 }
 
 export default function DispatcherDashboard() {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1252,6 +1252,11 @@ export async function registerRoutes(
     }
   });
 
+  app.get("/api/delivery/driver-locations", requireDispatcher, async (_req, res) => {
+    const locations = await storage.getLatestDriverLocations();
+    res.json(locations);
+  });
+
   app.post("/api/delivery/assign", requireDispatcher, async (req, res) => {
     try {
       const data = z.object({ orderId: z.string(), driverId: z.string() }).parse(req.body);


### PR DESCRIPTION
## Summary
- track latest driver GPS positions from driver_locations table
- expose dispatcher API for driver locations and update dashboard types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d2ae88348323a2c2b5fbbad7575b