### PR TITLE
Avoid reusePort on unsupported platforms

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -72,7 +72,7 @@ app.use((req, res, next) => {
   server.listen({
     port,
     host: "0.0.0.0",
-    reusePort: true,
+    ...(process.platform !== "darwin" ? { reusePort: true } : {}),
   }, () => {
     log(`serving on port ${port}`);
   });


### PR DESCRIPTION
## Summary
- Avoid setting `reusePort` on macOS to prevent ENOTSUP errors

## Testing
- `npm test`
- `SESSION_SECRET=secret npm run dev` *(fails: connect ENETUNREACH, but no ENOTSUP)*

------
https://chatgpt.com/codex/tasks/task_e_689f1ec393bc8323bfafa556fd2036e0