### PR TITLE
Remove Arabic name conditionals

### DIFF
--- a/client/src/components/cart-sidebar.tsx
+++ b/client/src/components/cart-sidebar.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { CartSummary } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { getTaxRate } from "@/lib/tax";
-import { useTranslation } from "@/lib/i18n";
 
 interface CartSidebarProps {
   cartSummary: CartSummary;
@@ -31,7 +30,6 @@ export function CartSidebar({
 }: CartSidebarProps) {
   const isMobile = useIsMobile();
   const taxRate = getTaxRate();
-  const { language } = useTranslation();
 
   return (
     <div className={`
@@ -65,12 +63,12 @@ export function CartSidebar({
                   {item.imageUrl && (
                     <img
                       src={item.imageUrl}
-                      alt={language === 'ar' && item.nameAr ? item.nameAr : item.name}
+                      alt={item.name}
                       className="w-12 h-12 rounded object-cover"
                     />
                   )}
                   <div className="flex-1">
-                    <h4 className="font-medium text-gray-900">{language === 'ar' && item.nameAr ? item.nameAr : item.name}</h4>
+                    <h4 className="font-medium text-gray-900">{item.name}</h4>
                     <div className="flex items-center space-x-2 mt-1">
                       <Button
                         variant="secondary"

--- a/client/src/components/clothing-grid.tsx
+++ b/client/src/components/clothing-grid.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/tooltip";
 import { ClothingItem } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useTranslation } from "@/lib/i18n";
 
 interface ClothingGridProps {
   onSelectClothing: (item: ClothingItem) => void;
@@ -32,7 +31,6 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
-  const { language } = useTranslation();
 
   const { data: clothingItems = [], isLoading } = useQuery({
     queryKey: ["/api/clothing-items", selectedCategory, searchQuery],
@@ -106,20 +104,20 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
                 {item.imageUrl && (
                   <img
                     src={item.imageUrl}
-                    alt={language === 'ar' && item.nameAr ? item.nameAr : item.name}
+                    alt={item.name}
                     className="w-full h-32 object-cover rounded-t-lg"
                   />
                 )}
                 <CardContent className="p-3">
                   <h3 className="font-medium text-gray-900 mb-1">
-                    {language === 'ar' && item.nameAr ? item.nameAr : item.name}
+                    {item.name}
                   </h3>
                   {item.description && (
                     <p className="text-sm text-gray-600 mb-2">{item.description}</p>
                   )}
                   <div className="text-center">
                     <span className="text-sm text-gray-500 capitalize">
-                      {language === 'ar' && item.nameAr ? item.nameAr : item.name}
+                      {item.name}
                     </span>
                   </div>
                   <TooltipProvider>

--- a/client/src/components/laundry-cart-sidebar.tsx
+++ b/client/src/components/laundry-cart-sidebar.tsx
@@ -14,7 +14,6 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useCurrency } from "@/lib/currency";
-import { useTranslation } from "@/lib/i18n";
 import { getTaxRate } from "@/lib/tax";
 
 interface LaundryCartSidebarProps {
@@ -49,7 +48,6 @@ export function LaundryCartSidebar({
   const queryClient = useQueryClient();
   const { formatCurrency } = useCurrency();
   const taxRate = getTaxRate();
-  const { language } = useTranslation();
 
   const [isCustomerDialogOpen, setIsCustomerDialogOpen] = useState(false);
   const [customerSearch, setCustomerSearch] = useState("");
@@ -292,16 +290,16 @@ export function LaundryCartSidebar({
                     {item.clothingItem.imageUrl && (
                       <img
                         src={item.clothingItem.imageUrl}
-                        alt={language === 'ar' && item.clothingItem.nameAr ? item.clothingItem.nameAr : item.clothingItem.name}
+                        alt={item.clothingItem.name}
                         className="w-12 h-12 rounded object-cover flex-shrink-0"
                       />
                     )}
                     <div className="flex-1 min-w-0">
                       <h4 className="font-medium text-gray-900 truncate">
-                        {language === 'ar' && item.clothingItem.nameAr ? item.clothingItem.nameAr : item.clothingItem.name}
+                        {item.clothingItem.name}
                       </h4>
                       <p className="text-sm text-blue-600 font-medium">
-                        {language === 'ar' && item.service.nameAr ? item.service.nameAr : item.service.name}
+                        {item.service.name}
                       </p>
                       <p className="text-xs text-gray-500">
                         {formatCurrency(item.service.price)} each

--- a/client/src/components/product-grid.tsx
+++ b/client/src/components/product-grid.tsx
@@ -5,12 +5,10 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useTranslation } from "@/lib/i18n";
 
 interface Product {
   id: string;
   name: string;
-  nameAr?: string;
   description?: string;
   categoryId?: string;
   price: string;
@@ -21,7 +19,6 @@ interface Product {
 interface Category {
   id: string;
   name: string;
-  nameAr?: string | null;
 }
 
 interface ProductGridProps {
@@ -35,7 +32,6 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
-  const { language } = useTranslation();
 
   const {
     data: fetchedCategories = [],
@@ -53,7 +49,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
   });
 
   const categories: Category[] = [
-    { id: "all", name: "All Items", nameAr: "All Items" },
+    { id: "all", name: "All Items" },
     ...fetchedCategories,
   ];
 
@@ -129,9 +125,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
               }`}
               onClick={() => setSelectedCategory(category.id)}
             >
-              {language === "ar" && category.nameAr
-                ? category.nameAr
-                : category.name}
+              {category.name}
             </Button>
           ))}
         </div>
@@ -154,12 +148,12 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
                 {product.imageUrl && (
                   <img
                     src={product.imageUrl}
-                    alt={language === 'ar' && product.nameAr ? product.nameAr : product.name}
+                    alt={product.name}
                     className="w-full h-32 object-cover rounded-t-lg"
                   />
                 )}
                 <CardContent className="p-3">
-                  <h3 className="font-medium text-gray-900 mb-1">{language === 'ar' && product.nameAr ? product.nameAr : product.name}</h3>
+                  <h3 className="font-medium text-gray-900 mb-1">{product.name}</h3>
                   {product.description && (
                     <p className="text-sm text-gray-600 mb-2">{product.description}</p>
                   )}

--- a/client/src/components/service-selection-modal.tsx
+++ b/client/src/components/service-selection-modal.tsx
@@ -12,7 +12,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ClothingItem, LaundryService } from "@shared/schema";
 import { useCurrency } from "@/lib/currency";
-import { useTranslation } from "@/lib/i18n";
 
 interface ServiceSelectionModalProps {
   isOpen: boolean;
@@ -28,7 +27,6 @@ interface ServiceSelectionModalProps {
 interface ServiceCategory {
   id: string;
   name: string;
-  nameAr?: string | null;
 }
 
 export function ServiceSelectionModal({
@@ -43,7 +41,6 @@ export function ServiceSelectionModal({
     null,
   );
   const { formatCurrency } = useCurrency();
-  const { language } = useTranslation();
 
   const { data: fetchedCategories = [] } = useQuery<ServiceCategory[]>({
     queryKey: ["/api/categories", "service"],
@@ -117,9 +114,7 @@ export function ServiceSelectionModal({
           <DialogTitle className="flex items-center space-x-2">
             <span>Select Service for</span>
             <span className="text-pos-primary">
-              {language === "ar" && clothingItem?.nameAr
-                ? clothingItem.nameAr
-                : clothingItem?.name}
+              {clothingItem?.name}
             </span>
           </DialogTitle>
         </DialogHeader>
@@ -140,9 +135,7 @@ export function ServiceSelectionModal({
               }`}
               onClick={() => setSelectedCategory(category.id)}
             >
-              {language === "ar" && category.nameAr
-                ? category.nameAr
-                : category.name}
+              {category.name}
             </Button>
           ))}
         </div>
@@ -164,9 +157,7 @@ export function ServiceSelectionModal({
               >
                 <CardContent className="p-4">
                   <h3 className="font-medium text-gray-900 mb-1">
-                    {language === "ar" && service.nameAr
-                      ? service.nameAr
-                      : service.name}
+                    {service.name}
                   </h3>
                   {service.description && (
                     <p className="text-sm text-gray-600 mb-2">
@@ -178,9 +169,7 @@ export function ServiceSelectionModal({
                       {formatCurrency(service.itemPrice)}
                     </span>
                     <span className="text-xs text-gray-500 capitalize bg-gray-100 px-2 py-1 rounded">
-                      {language === "ar" && category?.nameAr
-                        ? category.nameAr
-                        : category?.name || service.categoryId}
+                      {category?.name || service.categoryId}
                     </span>
                   </div>
 

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -6,7 +6,7 @@ export function useCart() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [paymentMethod, setPaymentMethod] = useState<"cash" | "card">("cash");
 
-  const addToCart = useCallback((product: { id: string; name: string; nameAr?: string; price: string; imageUrl?: string }) => {
+  const addToCart = useCallback((product: { id: string; name: string; price: string; imageUrl?: string }) => {
     setCartItems(prev => {
       const existing = prev.find(item => item.id === product.id);
       if (existing) {
@@ -21,7 +21,6 @@ export function useCart() {
       return [...prev, {
         id: product.id,
         name: product.name,
-        nameAr: product.nameAr,
         price,
         quantity: 1,
         total: price,

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -16,7 +16,6 @@ import { useLaundryCart } from "@/hooks/use-laundry-cart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { useTranslation } from "@/lib/i18n";
 import { LanguageSelector } from "@/components/language-selector";
 import { useCurrency } from "@/lib/currency";
 import { SystemSettings } from "@/components/system-settings";
@@ -38,7 +37,6 @@ export default function POS() {
   const isMobile = useIsMobile();
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { t, language } = useTranslation();
   const { formatCurrency } = useCurrency();
   const { user, branch } = useAuthContext();
   const username = user?.username ?? "";
@@ -123,7 +121,7 @@ export default function POS() {
     addToCart(clothingItem, service, quantity);
     toast({
       title: "Added to cart",
-      description: `${quantity}x ${language === 'ar' && clothingItem.nameAr ? clothingItem.nameAr : clothingItem.name} with ${language === 'ar' && service.nameAr ? service.nameAr : service.name} service`,
+      description: `${quantity}x ${clothingItem.name} with ${service.name} service`,
     });
   };
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -420,7 +420,6 @@ export interface LaundryCartItem {
 export interface CartItem {
   id: string;
   name: string;
-  nameAr?: string;
   price: number;
   quantity: number;
   total: number;


### PR DESCRIPTION
## Summary
- Display product, clothing, and service names directly without language checks
- Drop `nameAr` from cart item types and cart logic
- Simplify cart and selection components to rely on `name` for titles and alt text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2ee476448323a5f22593b0de409b