### PR TITLE
Remove deprecated Arabic name fields

### DIFF
--- a/client/src/components/admin/CategoryManager.tsx
+++ b/client/src/components/admin/CategoryManager.tsx
@@ -16,7 +16,7 @@ import type { Category, InsertCategory } from "@shared/schema";
 export function CategoryManager() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
-  const [formData, setFormData] = useState<Omit<InsertCategory, "nameAr">>({
+  const [formData, setFormData] = useState<InsertCategory>({
     name: "",
     type: "clothing",
     description: "",
@@ -31,7 +31,7 @@ export function CategoryManager() {
   });
 
   const createMutation = useMutation({
-    mutationFn: async (data: Omit<InsertCategory, "nameAr">) => {
+    mutationFn: async (data: InsertCategory) => {
       const response = await apiRequest("POST", "/api/categories", data);
       return await response.json();
     },
@@ -50,7 +50,7 @@ export function CategoryManager() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: Omit<InsertCategory, "nameAr"> }) => {
+    mutationFn: async ({ id, data }: { id: string; data: InsertCategory }) => {
       const response = await apiRequest("PUT", `/api/categories/${id}`, data);
       return await response.json();
     },

--- a/client/src/hooks/use-laundry-cart.tsx
+++ b/client/src/hooks/use-laundry-cart.tsx
@@ -6,7 +6,7 @@ export function useLaundryCart() {
   const [cartItems, setCartItems] = useState<LaundryCartItem[]>([]);
   const [paymentMethod, setPaymentMethod] = useState<"cash" | "card" | "pay_later">("cash");
 
-  const addToCart = useCallback((clothingItem: Omit<ClothingItem, "nameAr">, service: Omit<LaundryService, "nameAr"> & { itemPrice?: string }, quantity: number = 1) => {
+  const addToCart = useCallback((clothingItem: ClothingItem, service: LaundryService & { itemPrice?: string }, quantity: number = 1) => {
     setCartItems(prev => {
       // Create unique ID combining clothing item and service
       const uniqueId = `${clothingItem.id}-${service.id}`;

--- a/migrations/0010_drop_name_ar_columns.sql
+++ b/migrations/0010_drop_name_ar_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "clothing_items" DROP COLUMN IF EXISTS "name_ar";
+ALTER TABLE "laundry_services" DROP COLUMN IF EXISTS "name_ar";
+ALTER TABLE "products" DROP COLUMN IF EXISTS "name_ar";
+ALTER TABLE "categories" DROP COLUMN IF EXISTS "name_ar";

--- a/server/routes.products.test.ts
+++ b/server/routes.products.test.ts
@@ -31,7 +31,6 @@ function createApp(storage: any) {
         items = items.filter(
           (p: any) =>
             p.name.toLowerCase().includes(term) ||
-            p.nameAr?.toLowerCase().includes(term) ||
             p.description?.toLowerCase().includes(term),
         );
       }
@@ -60,8 +59,8 @@ function createApp(storage: any) {
 
 test('GET /api/products filters by search and category', async () => {
   const products = [
-    { id: 'p1', name: 'Soap', nameAr: 'صابونة', description: 'Hand soap', categoryId: 'c1' },
-    { id: 'p2', name: 'Shampoo', nameAr: 'شامبو', description: 'Hair cleaner', categoryId: 'c2' },
+    { id: 'p1', name: 'Soap', description: 'Hand soap', categoryId: 'c1' },
+    { id: 'p2', name: 'Shampoo', description: 'Hair cleaner', categoryId: 'c2' },
   ];
   const storage = {
     getProducts: async (_branchId: string) => products,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -446,10 +446,10 @@ export async function registerRoutes(
         : await storage.getProducts(user.branchId || undefined);
 
       if (search) {
+        const term = search.toLowerCase();
         items = items.filter(product =>
-          product.name.toLowerCase().includes(search.toLowerCase()) ||
-          product.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          product.description?.toLowerCase().includes(search.toLowerCase())
+          product.name.toLowerCase().includes(term) ||
+          product.description?.toLowerCase().includes(term)
         );
       }
 
@@ -514,10 +514,10 @@ export async function registerRoutes(
         : await storage.getClothingItems(userId);
 
       if (search) {
+        const term = search.toLowerCase();
         items = items.filter((item) =>
-          item.name.toLowerCase().includes(search.toLowerCase()) ||
-          item.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          item.description?.toLowerCase().includes(search.toLowerCase()),
+          item.name.toLowerCase().includes(term) ||
+          item.description?.toLowerCase().includes(term),
         );
       }
 
@@ -621,10 +621,10 @@ export async function registerRoutes(
         : await storage.getLaundryServices(userId);
 
       if (search) {
+        const term = search.toLowerCase();
         services = services.filter((service) =>
-          service.name.toLowerCase().includes(search.toLowerCase()) ||
-          service.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          service.description?.toLowerCase().includes(search.toLowerCase()),
+          service.name.toLowerCase().includes(term) ||
+          service.description?.toLowerCase().includes(term),
         );
       }
 

--- a/server/seed-data.ts
+++ b/server/seed-data.ts
@@ -5,13 +5,13 @@ import {
 } from "@shared/schema";
 
 export const CATEGORY_SEEDS: Omit<InsertCategory, "userId">[] = [
-  { name: "Normal Iron", nameAr: "كي عادي", type: "service", isActive: true },
-  { name: "Normal Wash", nameAr: "غسيل عادي", type: "service", isActive: true },
-  { name: "Normal Wash & Iron", nameAr: "غسيل وكي عادي", type: "service", isActive: true },
-  { name: "Urgent Iron", nameAr: "كي مستعجل", type: "service", isActive: true },
-  { name: "Urgent Wash", nameAr: "غسيل مستعجل", type: "service", isActive: true },
-  { name: "Urgent Wash & Iron", nameAr: "غسيل وكي مستعجل", type: "service", isActive: true },
-  { name: "Clothing Items", nameAr: "ملابس", type: "clothing", isActive: true },
+  { name: "Normal Iron", type: "service", isActive: true },
+  { name: "Normal Wash", type: "service", isActive: true },
+  { name: "Normal Wash & Iron", type: "service", isActive: true },
+  { name: "Urgent Iron", type: "service", isActive: true },
+  { name: "Urgent Wash", type: "service", isActive: true },
+  { name: "Urgent Wash & Iron", type: "service", isActive: true },
+  { name: "Clothing Items", type: "clothing", isActive: true },
 ];
 
 export const CLOTHING_ITEM_SEEDS: Omit<

--- a/server/seed-prices.ts
+++ b/server/seed-prices.ts
@@ -1,13 +1,11 @@
 export interface ItemPricing {
   name: string;
-  nameAr: string;
   prices: Record<string, number>;
 }
 
 export const PRICE_MATRIX: ItemPricing[] = [
   {
     name: "Thobe",
-    nameAr: "ثوب",
     prices: {
       "Normal Iron": 4,
       "Normal Wash": 5,
@@ -19,7 +17,6 @@ export const PRICE_MATRIX: ItemPricing[] = [
   },
   {
     name: "Shirt",
-    nameAr: "قميص",
     prices: {
       "Normal Iron": 2,
       "Normal Wash": 3,
@@ -31,7 +28,6 @@ export const PRICE_MATRIX: ItemPricing[] = [
   },
   {
     name: "T-Shirt",
-    nameAr: "تيشيرت",
     prices: {
       "Normal Iron": 1.5,
       "Normal Wash": 2.5,
@@ -43,7 +39,6 @@ export const PRICE_MATRIX: ItemPricing[] = [
   },
   {
     name: "Trouser",
-    nameAr: "بنطال",
     prices: {
       "Normal Iron": 2.5,
       "Normal Wash": 3.5,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -224,8 +224,8 @@ test('createClothingItem seeds default prices for existing services', async () =
           where: () => {
             if (table === laundryServices) {
               return [
-                { id: 's1', price: '5.00', userId: 'u1', name: 'Wash', nameAr: null, description: null, categoryId: 'c1' },
-                { id: 's2', price: '3.00', userId: 'u1', name: 'Iron', nameAr: null, description: null, categoryId: 'c2' },
+                { id: 's1', price: '5.00', userId: 'u1', name: 'Wash', description: null, categoryId: 'c1' },
+                { id: 's2', price: '3.00', userId: 'u1', name: 'Iron', description: null, categoryId: 'c2' },
               ];
             }
             return [];

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -395,7 +395,6 @@ export class MemStorage {
     const newProduct: Product = {
       id,
       name: product.name,
-      nameAr: product.nameAr || null,
       description: product.description || null,
       categoryId: product.categoryId || null,
       price: product.price,
@@ -418,7 +417,6 @@ export class MemStorage {
     const updated: Product = {
       ...existing,
       name: product.name ?? existing.name,
-      nameAr: product.nameAr ?? existing.nameAr,
       description: product.description ?? existing.description,
       categoryId: product.categoryId ?? existing.categoryId,
       price: product.price ?? existing.price,
@@ -451,7 +449,6 @@ export class MemStorage {
     const newItem: ClothingItem = {
       id,
       name: item.name,
-      nameAr: null,
       description: item.description || null,
       categoryId: item.categoryId,
       imageUrl: item.imageUrl || null,
@@ -515,7 +512,6 @@ export class MemStorage {
     const newService: LaundryService = {
       id,
       name: service.name,
-      nameAr: null,
       description: service.description || null,
       price: service.price,
       categoryId: service.categoryId,
@@ -904,10 +900,10 @@ export class DatabaseStorage implements IStorage {
     categoryData: Omit<InsertCategory, "userId">,
     userId: string,
   ): Promise<Category> {
-    const { name, nameAr, type, description, isActive } = categoryData;
+    const { name, type, description, isActive } = categoryData;
     const [category] = await db
       .insert(categories)
-      .values({ name, nameAr, type, description, isActive, userId })
+      .values({ name, type, description, isActive, userId })
       .returning();
     return category;
   }
@@ -917,10 +913,10 @@ export class DatabaseStorage implements IStorage {
     categoryData: Partial<Omit<InsertCategory, "userId">>,
     userId: string,
   ): Promise<Category | undefined> {
-    const { name, nameAr, type, description, isActive } = categoryData;
+    const { name, type, description, isActive } = categoryData;
     const [updated] = await db
       .update(categories)
-      .set({ name, nameAr, type, description, isActive, updatedAt: new Date() })
+      .set({ name, type, description, isActive, updatedAt: new Date() })
       .where(and(eq(categories.id, id), eq(categories.userId, userId)))
       .returning();
     return updated || undefined;
@@ -1143,7 +1139,6 @@ export class DatabaseStorage implements IStorage {
       .select({
         id: laundryServices.id,
         name: laundryServices.name,
-        nameAr: laundryServices.nameAr,
         description: laundryServices.description,
         categoryId: laundryServices.categoryId,
         price: laundryServices.price,
@@ -1292,14 +1287,13 @@ export class DatabaseStorage implements IStorage {
           clothingItemId = existingItem.id;
           await tx
             .update(clothingItems)
-            .set({ nameAr: row.itemAr, imageUrl: row.imageUrl })
+            .set({ imageUrl: row.imageUrl })
             .where(eq(clothingItems.id, existingItem.id));
         } else {
           const [insertedItem] = await tx
             .insert(clothingItems)
             .values({
               name: row.itemEn,
-              nameAr: row.itemAr,
               imageUrl: row.imageUrl,
               categoryId: clothingCategoryId,
               userId,

--- a/server/user.seed.test.ts
+++ b/server/user.seed.test.ts
@@ -73,7 +73,7 @@ test('new users are seeded with default data', async () => {
 
     assert.ok(
       insertedCategories.some(
-        (c) => c.name === 'Normal Iron' && c.nameAr === 'كي عادي'
+        (c) => c.name === 'Normal Iron'
       )
     );
     assert.ok(insertedClothing.some((i) => i.name === 'Thobe'));

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -6,7 +6,6 @@ import { z } from "zod";
 export const clothingItems = pgTable("clothing_items", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
-  nameAr: text("name_ar"),
   description: text("description"),
   categoryId: varchar("category_id").references(() => categories.id).notNull(),
   imageUrl: text("image_url"),
@@ -16,7 +15,6 @@ export const clothingItems = pgTable("clothing_items", {
 export const laundryServices = pgTable("laundry_services", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
-  nameAr: text("name_ar"),
   description: text("description"),
   price: decimal("price", { precision: 10, scale: 2 }).notNull(),
   categoryId: varchar("category_id").references(() => categories.id).notNull(),
@@ -42,7 +40,6 @@ export const itemServicePrices = pgTable(
 export const products = pgTable("products", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
-  nameAr: text("name_ar"),
   description: text("description"),
   categoryId: varchar("category_id").references(() => categories.id),
   price: decimal("price", { precision: 10, scale: 2 }).notNull(),
@@ -83,7 +80,6 @@ export const users = pgTable("users", {
 export const categories = pgTable("categories", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
-  nameAr: text("name_ar"),
   type: text("type").notNull(), // 'clothing' or 'service'
   description: text("description"),
   isActive: boolean("is_active").default(true).notNull(),
@@ -259,14 +255,12 @@ export const loyaltyHistory = pgTable("loyalty_history", {
 export const insertClothingItemSchema = createInsertSchema(clothingItems).omit({
   id: true,
   userId: true,
-  nameAr: true,
 });
 
 export const insertLaundryServiceSchema = createInsertSchema(laundryServices)
   .omit({
     id: true,
     userId: true,
-    nameAr: true,
   })
   .extend({
     price: z
@@ -413,8 +407,8 @@ export type BulkUploadResult = z.infer<typeof bulkUploadResultSchema>;
 
 export interface LaundryCartItem {
   id: string;
-  clothingItem: Omit<ClothingItem, "nameAr">;
-  service: Omit<LaundryService, "nameAr">;
+  clothingItem: ClothingItem;
+  service: LaundryService;
   quantity: number;
   total: number;
 }


### PR DESCRIPTION
## Summary
- drop `nameAr` columns from clothing items, laundry services, products, and categories schema
- clean up storage, routes, seeds, and tests to use only `name`
- add migration to remove obsolete `name_ar` columns and simplify search filtering

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f37ae6e3883238c56ac6d8bba23d5