### PR TITLE
Use name field for search instead of nameAr

### DIFF
--- a/client/src/components/inventory-management.tsx
+++ b/client/src/components/inventory-management.tsx
@@ -270,14 +270,15 @@ export function InventoryManagement() {
   };
 
   // Filter items based on search
+  const search = searchQuery.toLowerCase();
   const filteredClothing = clothingItems.filter(item =>
-    item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    item.categoryId.toLowerCase().includes(searchQuery.toLowerCase())
+    item.name.toLowerCase().includes(search) ||
+    item.categoryId.toLowerCase().includes(search)
   );
 
   const filteredServices = services.filter(service =>
-    service.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    service.categoryId.toLowerCase().includes(searchQuery.toLowerCase())
+    service.name.toLowerCase().includes(search) ||
+    service.categoryId.toLowerCase().includes(search)
   );
 
   return (

--- a/server/routes.products.test.ts
+++ b/server/routes.products.test.ts
@@ -31,7 +31,6 @@ function createApp(storage: any) {
         items = items.filter(
           (p: any) =>
             p.name.toLowerCase().includes(term) ||
-            p.nameAr?.toLowerCase().includes(term) ||
             p.description?.toLowerCase().includes(term),
         );
       }
@@ -60,8 +59,8 @@ function createApp(storage: any) {
 
 test('GET /api/products filters by search and category', async () => {
   const products = [
-    { id: 'p1', name: 'Soap', nameAr: 'صابونة', description: 'Hand soap', categoryId: 'c1' },
-    { id: 'p2', name: 'Shampoo', nameAr: 'شامبو', description: 'Hair cleaner', categoryId: 'c2' },
+    { id: 'p1', name: 'Soap', description: 'Hand soap', categoryId: 'c1' },
+    { id: 'p2', name: 'Shampoo', description: 'Hair cleaner', categoryId: 'c2' },
   ];
   const storage = {
     getProducts: async (_branchId: string) => products,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -446,10 +446,10 @@ export async function registerRoutes(
         : await storage.getProducts(user.branchId || undefined);
 
       if (search) {
+        const searchLower = search.toLowerCase();
         items = items.filter(product =>
-          product.name.toLowerCase().includes(search.toLowerCase()) ||
-          product.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          product.description?.toLowerCase().includes(search.toLowerCase())
+          product.name.toLowerCase().includes(searchLower) ||
+          product.description?.toLowerCase().includes(searchLower)
         );
       }
 
@@ -514,10 +514,10 @@ export async function registerRoutes(
         : await storage.getClothingItems(userId);
 
       if (search) {
+        const searchLower = search.toLowerCase();
         items = items.filter((item) =>
-          item.name.toLowerCase().includes(search.toLowerCase()) ||
-          item.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          item.description?.toLowerCase().includes(search.toLowerCase()),
+          item.name.toLowerCase().includes(searchLower) ||
+          item.description?.toLowerCase().includes(searchLower),
         );
       }
 
@@ -621,10 +621,10 @@ export async function registerRoutes(
         : await storage.getLaundryServices(userId);
 
       if (search) {
+        const searchLower = search.toLowerCase();
         services = services.filter((service) =>
-          service.name.toLowerCase().includes(search.toLowerCase()) ||
-          service.nameAr?.toLowerCase().includes(search.toLowerCase()) ||
-          service.description?.toLowerCase().includes(search.toLowerCase()),
+          service.name.toLowerCase().includes(searchLower) ||
+          service.description?.toLowerCase().includes(searchLower),
         );
       }
 


### PR DESCRIPTION
## Summary
- Ensure inventory search lowers the query once before comparing
- Filter products, clothing items, and services by lowercased `name` field instead of `nameAr`
- Update product route tests to match new search behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3c5b97088323acac91bbc6ed0301