### PR TITLE
Invalidate inventory queries after price update

### DIFF
--- a/client/src/components/inventory-management.tsx
+++ b/client/src/components/inventory-management.tsx
@@ -209,6 +209,9 @@ export function InventoryManagement() {
       return response.json();
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/item-service-prices"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/clothing-items"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/laundry-services"] });
       setIsPriceModalOpen(false);
       priceForm.reset();
       toast({ title: "Price saved successfully" });


### PR DESCRIPTION
## Summary
- invalidate pricing, clothing item, and service queries after saving item-service prices so UI refreshes

## Testing
- `npm test`
- `SESSION_SECRET=devsecret npm run dev` *(fails: connect ENETUNREACH ...)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e92ca40832392244902294098c2