### PR TITLE
feat: internationalize ui components

### DIFF
--- a/client/src/components/admin/CategoryManager.tsx
+++ b/client/src/components/admin/CategoryManager.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { Plus, Edit, Trash2 } from "lucide-react";
 import type { Category, InsertCategory } from "@shared/schema";
+import { useTranslation } from "@/lib/i18n";
 
 export function CategoryManager() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -25,6 +26,7 @@ export function CategoryManager() {
 
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   const { data: categories = [], isLoading } = useQuery<Category[]>({
     queryKey: ["/api/categories"],
@@ -36,13 +38,13 @@ export function CategoryManager() {
       return await response.json();
     },
     onSuccess: () => {
-      toast({ title: "Category created successfully" });
+      toast({ title: t.categoryCreated });
       queryClient.invalidateQueries({ queryKey: ["/api/categories"] });
       resetForm();
     },
     onError: (error) => {
       toast({
-        title: "Error creating category",
+        title: t.errorCreatingCategory,
         description: error.message,
         variant: "destructive",
       });
@@ -55,13 +57,13 @@ export function CategoryManager() {
       return await response.json();
     },
     onSuccess: () => {
-      toast({ title: "Category updated successfully" });
+      toast({ title: t.categoryUpdated });
       queryClient.invalidateQueries({ queryKey: ["/api/categories"] });
       resetForm();
     },
     onError: (error) => {
       toast({
-        title: "Error updating category",
+        title: t.errorUpdatingCategory,
         description: error.message,
         variant: "destructive",
       });
@@ -74,12 +76,12 @@ export function CategoryManager() {
       return await response.json();
     },
     onSuccess: () => {
-      toast({ title: "Category deleted successfully" });
+      toast({ title: t.categoryDeleted });
       queryClient.invalidateQueries({ queryKey: ["/api/categories"] });
     },
     onError: (error) => {
       toast({
-        title: "Error deleting category",
+        title: t.errorDeletingCategory,
         description: error.message,
         variant: "destructive",
       });
@@ -127,29 +129,26 @@ export function CategoryManager() {
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">Category Management</h2>
+        <h2 className="text-2xl font-bold">{t.categoryManagement}</h2>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogTrigger asChild>
             <Button onClick={() => setEditingCategory(null)}>
               <Plus className="w-4 h-4 mr-2" />
-              Add Category
+              {t.add} {t.category}
             </Button>
           </DialogTrigger>
           <DialogContent className="sm:max-w-[425px]">
             <DialogHeader>
               <DialogTitle>
-                {editingCategory ? "Edit Category" : "Add New Category"}
+                {editingCategory ? `${t.edit} ${t.category}` : `${t.add} ${t.category}`}
               </DialogTitle>
-              <DialogDescription>
-                {editingCategory ? "Update the category details" : "Create a new category for clothing items or services"}
-              </DialogDescription>
             </DialogHeader>
             <form onSubmit={handleSubmit}>
               <div className="grid gap-4 py-4">
                 <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="name" className="text-right">
-                    Name
-                  </Label>
+                <Label htmlFor="name" className="text-right">
+                  {t.name}
+                </Label>
                   <Input
                     id="name"
                     value={formData.name}
@@ -159,41 +158,41 @@ export function CategoryManager() {
                   />
                 </div>
                 <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="type" className="text-right">
-                    Type
-                  </Label>
+                <Label htmlFor="type" className="text-right">
+                  {t.type}
+                </Label>
                   <Select
                     value={formData.type}
                     onValueChange={(value) => setFormData({ ...formData, type: value })}
                   >
                     <SelectTrigger className="col-span-3">
-                      <SelectValue />
+                      <SelectValue placeholder={t.type} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="clothing">Clothing</SelectItem>
-                      <SelectItem value="service">Service</SelectItem>
+                      <SelectItem value="clothing">{t.clothing}</SelectItem>
+                      <SelectItem value="service">{t.service}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
                 <div className="grid grid-cols-4 items-center gap-4">
                   <Label htmlFor="description" className="text-right">
-                    Description
+                    {t.description}
                   </Label>
                   <Textarea
                     id="description"
                     value={formData.description || ""}
                     onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                     className="col-span-3"
-                    placeholder="Optional description"
+                    placeholder={t.optionalDescription}
                   />
                 </div>
               </div>
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={resetForm}>
-                  Cancel
+                  {t.cancel}
                 </Button>
                 <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
-                  {editingCategory ? "Update" : "Create"}
+                  {editingCategory ? t.update : t.create}
                 </Button>
               </DialogFooter>
             </form>
@@ -204,8 +203,8 @@ export function CategoryManager() {
       <div className="grid md:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Clothing Categories</CardTitle>
-            <CardDescription>Categories for clothing items</CardDescription>
+            <CardTitle>{t.clothingCategories}</CardTitle>
+            <CardDescription>{t.categoriesForClothingItems}</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
@@ -217,7 +216,7 @@ export function CategoryManager() {
                   <div className="flex items-center gap-2">
                     <span className="font-medium">{category.name}</span>
                     <Badge variant={category.isActive ? "default" : "secondary"}>
-                      {category.isActive ? "Active" : "Inactive"}
+                      {category.isActive ? t.active : t.inactive}
                     </Badge>
                   </div>
                   <div className="flex items-center gap-2">
@@ -240,7 +239,7 @@ export function CategoryManager() {
                 </div>
               ))}
               {clothingCategories.length === 0 && (
-                <p className="text-gray-500 text-center py-4">No clothing categories found</p>
+                <p className="text-gray-500 text-center py-4">{t.noClothingCategoriesFound}</p>
               )}
             </div>
           </CardContent>
@@ -248,8 +247,8 @@ export function CategoryManager() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Service Categories</CardTitle>
-            <CardDescription>Categories for laundry services</CardDescription>
+            <CardTitle>{t.serviceCategories}</CardTitle>
+            <CardDescription>{t.categoriesForLaundryServices}</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
@@ -261,7 +260,7 @@ export function CategoryManager() {
                   <div className="flex items-center gap-2">
                     <span className="font-medium">{category.name}</span>
                     <Badge variant={category.isActive ? "default" : "secondary"}>
-                      {category.isActive ? "Active" : "Inactive"}
+                      {category.isActive ? t.active : t.inactive}
                     </Badge>
                   </div>
                   <div className="flex items-center gap-2">
@@ -284,7 +283,7 @@ export function CategoryManager() {
                 </div>
               ))}
               {serviceCategories.length === 0 && (
-                <p className="text-gray-500 text-center py-4">No service categories found</p>
+                <p className="text-gray-500 text-center py-4">{t.noServiceCategoriesFound}</p>
               )}
             </div>
           </CardContent>

--- a/client/src/components/clothing-grid.tsx
+++ b/client/src/components/clothing-grid.tsx
@@ -12,25 +12,27 @@ import {
 } from "@/components/ui/tooltip";
 import { ClothingItem } from "@shared/schema";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useTranslation } from "@/lib/i18n";
 
 interface ClothingGridProps {
   onSelectClothing: (item: ClothingItem) => void;
 }
 
-const clothingCategories = [
-  { id: "all", label: "All Items" },
-  { id: "pants", label: "Pants" },
-  { id: "shirts", label: "Shirts" },
-  { id: "traditional", label: "Traditional" },
-  { id: "dresses", label: "Dresses" },
-  { id: "formal", label: "Formal" },
-  { id: "linens", label: "Linens" }
-];
-
 export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
+  const { t } = useTranslation();
+
+  const clothingCategories = [
+    { id: "all", label: t.allItems },
+    { id: "pants", label: t.pants },
+    { id: "shirts", label: t.shirts },
+    { id: "traditional", label: t.traditional },
+    { id: "dresses", label: t.dresses },
+    { id: "formal", label: t.formal },
+    { id: "linens", label: t.linens },
+  ];
 
   const { data: clothingItems = [], isLoading } = useQuery({
     queryKey: ["/api/clothing-items", selectedCategory, searchQuery],
@@ -48,7 +50,7 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
   }) as { data: ClothingItem[], isLoading: boolean };
 
   if (isLoading) {
-    return <div className="flex-1 flex items-center justify-center">Loading clothing items...</div>;
+    return <div className="flex-1 flex items-center justify-center">{t.loadingClothingItems}</div>;
   }
 
   return (
@@ -60,7 +62,7 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
             <Input
               type="text"
-              placeholder="Search clothing items..."
+              placeholder={t.searchClothingItems}
               className="pl-10 py-3 text-base w-full"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -92,7 +94,7 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
       <div className="flex-1 overflow-y-auto p-4">
         {clothingItems.length === 0 ? (
           <div className="flex items-center justify-center h-64 text-gray-500">
-            No clothing items found
+            {t.noClothingItemsFound}
           </div>
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
@@ -127,11 +129,11 @@ export function ClothingGrid({ onSelectClothing }: ClothingGridProps) {
                           className="mt-3 w-full bg-pos-secondary hover:bg-green-600 text-white"
                           onClick={() => onSelectClothing(item)}
                         >
-                          Select Service
+                          {t.selectService}
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        Service prices will be shown in the next step
+                        {t.servicePriceInfo}
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/client/src/components/inventory-management.tsx
+++ b/client/src/components/inventory-management.tsx
@@ -140,7 +140,7 @@ export function InventoryManagement() {
       queryClient.invalidateQueries({ queryKey: ["/api/clothing-items"] });
       setIsClothingModalOpen(false);
       clothingForm.reset();
-      toast({ title: "Clothing item created successfully" });
+      toast({ title: t.clothingItemCreated });
     }
   });
 
@@ -154,7 +154,7 @@ export function InventoryManagement() {
       setIsClothingModalOpen(false);
       setEditingClothing(null);
       clothingForm.reset();
-      toast({ title: "Clothing item updated successfully" });
+      toast({ title: t.clothingItemUpdated });
     }
   });
 
@@ -165,7 +165,7 @@ export function InventoryManagement() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/clothing-items"] });
-      toast({ title: "Clothing item deleted successfully" });
+      toast({ title: t.clothingItemDeleted });
     }
   });
 
@@ -179,7 +179,7 @@ export function InventoryManagement() {
       queryClient.invalidateQueries({ queryKey: ["/api/laundry-services"] });
       setIsServiceModalOpen(false);
       serviceForm.reset();
-      toast({ title: "Service created successfully" });
+      toast({ title: t.serviceCreated });
     }
   });
 
@@ -193,7 +193,7 @@ export function InventoryManagement() {
       setIsServiceModalOpen(false);
       setEditingService(null);
       serviceForm.reset();
-      toast({ title: "Service updated successfully" });
+      toast({ title: t.serviceUpdated });
     }
   });
 
@@ -204,7 +204,7 @@ export function InventoryManagement() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/laundry-services"] });
-      toast({ title: "Service deleted successfully" });
+      toast({ title: t.serviceDeleted });
     }
   });
 
@@ -290,13 +290,13 @@ export function InventoryManagement() {
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center space-x-3">
             <Package className="h-8 w-8 text-pos-primary" />
-            <h1 className="text-3xl font-bold text-gray-900">Inventory Management</h1>
+            <h1 className="text-3xl font-bold text-gray-900">{t.inventoryManagement}</h1>
           </div>
           
           <div className="relative w-80">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
             <Input
-              placeholder="Search items and services..."
+              placeholder={t.searchItemsServices}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-10"

--- a/client/src/components/pos-header.tsx
+++ b/client/src/components/pos-header.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { LanguageSelector } from "@/components/language-selector";
 import { Link } from "wouter";
+import { useTranslation } from "@/lib/i18n";
 
 interface POSHeaderProps {
   cartItemCount?: number;
@@ -17,6 +18,7 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
   const { user, branch } = useAuthContext();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   const logoutMutation = useMutation({
     mutationFn: async () => {
@@ -24,12 +26,12 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
       return await response.json();
     },
     onSuccess: () => {
-      toast({ title: "Logged out successfully" });
+      toast({ title: t.logoutSuccess });
       queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
     },
     onError: (error) => {
       toast({
-        title: "Logout failed",
+        title: t.logoutFailed,
         description: error.message,
         variant: "destructive",
       });
@@ -47,15 +49,15 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
           <div className="flex items-center space-x-4">
             <img
               src={branch?.logoUrl || defaultLogo}
-              alt="Laundry Logo"
+              alt={t.laundryManagementSystem}
               className="w-8 h-8 object-cover rounded"
             />
-            <h1 className="text-xl font-medium">Laundry Management System</h1>
+            <h1 className="text-xl font-medium">{t.laundryManagementSystem}</h1>
           </div>
           <div className="flex items-center space-x-6">
             <div className="hidden md:flex items-center space-x-2 text-sm">
               <Store className="h-4 w-4" />
-              <span>{branch?.name || "Main Store"}</span>
+              <span>{branch?.name || t.mainStore}</span>
             </div>
             
             {/* Cart Button */}
@@ -66,7 +68,7 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
               onClick={onToggleCart}
             >
               <ShoppingCart className="h-4 w-4" />
-              <span className="hidden sm:inline">Cart</span>
+              <span className="hidden sm:inline">{t.cart}</span>
               {cartItemCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center font-medium">
                   {cartItemCount > 99 ? '99+' : cartItemCount}
@@ -89,7 +91,7 @@ export function POSHeader({ cartItemCount = 0, onToggleCart }: POSHeaderProps) {
                   className="p-2 hover:bg-blue-700 text-white hover:text-white flex items-center space-x-2"
                 >
                   <Settings className="h-4 w-4" />
-                  <span className="hidden sm:inline">Admin</span>
+                  <span className="hidden sm:inline">{t.admin}</span>
                 </Button>
               </Link>
             )}

--- a/client/src/components/product-grid.tsx
+++ b/client/src/components/product-grid.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useTranslation } from "@/lib/i18n";
 
 interface Product {
   id: string;
@@ -32,6 +33,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const isMobile = useIsMobile();
+  const { t } = useTranslation();
 
   const {
     data: fetchedCategories = [],
@@ -49,7 +51,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
   });
 
   const categories: Category[] = [
-    { id: "all", name: "All Items" },
+    { id: "all", name: t.allItems },
     ...fetchedCategories,
   ];
 
@@ -74,15 +76,15 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
   });
 
   if (categoriesLoading) {
-    return <div className="flex-1 flex items-center justify-center">Loading categories...</div>;
+    return <div className="flex-1 flex items-center justify-center">{t.loadingCategories}</div>;
   }
 
   if (categoriesError) {
-    return <div className="flex-1 flex items-center justify-center">Failed to load categories</div>;
+    return <div className="flex-1 flex items-center justify-center">{t.failedToLoadCategories}</div>;
   }
 
   if (productsLoading) {
-    return <div className="flex-1 flex items-center justify-center">Loading products...</div>;
+    return <div className="flex-1 flex items-center justify-center">{t.loadingProducts}</div>;
   }
 
   return (
@@ -94,7 +96,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
             <Input
               type="text"
-              placeholder="Search products..."
+              placeholder={t.searchProducts}
               className="pl-10 py-3 text-base"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -106,7 +108,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
               className="bg-pos-primary hover:bg-blue-700 text-white px-4 py-3 flex items-center space-x-2"
             >
               <ShoppingCart className="h-4 w-4" />
-              <span>Cart ({cartItemCount})</span>
+              <span>{t.cart} ({cartItemCount})</span>
             </Button>
           )}
         </div>
@@ -135,12 +137,12 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
       <div className="flex-1 overflow-y-auto p-4">
         {products.length === 0 ? (
           <div className="flex items-center justify-center h-64 text-gray-500">
-            No products found
+            {t.noProductsFound}
           </div>
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
             {products.map((product) => (
-              <Card 
+              <Card
                 key={product.id}
                 className="hover:shadow-material-lg transition-shadow cursor-pointer"
                 onClick={() => onAddToCart(product)}
@@ -162,7 +164,7 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
                       ${parseFloat(product.price).toFixed(2)}
                     </span>
                     <span className="text-xs text-gray-500">
-                      Stock: {product.stock}
+                      {t.stock}: {product.stock}
                     </span>
                   </div>
                 </CardContent>

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -170,6 +170,58 @@ export interface Translations {
   welcome: string;
   loginFailed: string;
   missingCredentials: string;
+  logoutSuccess: string;
+  logoutFailed: string;
+  mainStore: string;
+  laundryManagementSystem: string;
+  allItems: string;
+  loadingCategories: string;
+  failedToLoadCategories: string;
+  loadingProducts: string;
+  loadingClothingItems: string;
+  searchProducts: string;
+  searchItemsServices: string;
+  noProductsFound: string;
+  stock: string;
+  searchClothingItems: string;
+  noClothingItemsFound: string;
+  servicePriceInfo: string;
+  categoryManagement: string;
+  inventoryManagement: string;
+  categoryCreated: string;
+  categoryUpdated: string;
+  categoryDeleted: string;
+  errorCreatingCategory: string;
+  errorUpdatingCategory: string;
+  errorDeletingCategory: string;
+  type: string;
+  description: string;
+  optionalDescription: string;
+  create: string;
+  update: string;
+  clothing: string;
+  service: string;
+  category: string;
+  clothingCategories: string;
+  serviceCategories: string;
+  categoriesForClothingItems: string;
+  categoriesForLaundryServices: string;
+  active: string;
+  inactive: string;
+  noClothingCategoriesFound: string;
+  noServiceCategoriesFound: string;
+  pants: string;
+  shirts: string;
+  traditional: string;
+  dresses: string;
+  formal: string;
+  linens: string;
+  clothingItemCreated: string;
+  clothingItemUpdated: string;
+  clothingItemDeleted: string;
+  serviceCreated: string;
+  serviceUpdated: string;
+  serviceDeleted: string;
 }
 
 export const translations: Record<Language, Translations> = {
@@ -340,6 +392,58 @@ export const translations: Record<Language, Translations> = {
     welcome: "Welcome to the Laundry Management System",
     loginFailed: "Login Failed",
     missingCredentials: "Please enter both username and password",
+    logoutSuccess: "Logged out successfully",
+    logoutFailed: "Logout failed",
+    mainStore: "Main Store",
+    laundryManagementSystem: "Laundry Management System",
+    allItems: "All Items",
+    loadingCategories: "Loading categories...",
+    failedToLoadCategories: "Failed to load categories",
+    loadingProducts: "Loading products...",
+    loadingClothingItems: "Loading clothing items...",
+    searchProducts: "Search products...",
+    searchItemsServices: "Search items and services...",
+    noProductsFound: "No products found",
+    stock: "Stock",
+    searchClothingItems: "Search clothing items...",
+    noClothingItemsFound: "No clothing items found",
+    servicePriceInfo: "Service prices will be shown in the next step",
+    categoryManagement: "Category Management",
+    inventoryManagement: "Inventory Management",
+    categoryCreated: "Category created successfully",
+    categoryUpdated: "Category updated successfully",
+    categoryDeleted: "Category deleted successfully",
+    errorCreatingCategory: "Error creating category",
+    errorUpdatingCategory: "Error updating category",
+    errorDeletingCategory: "Error deleting category",
+    type: "Type",
+    description: "Description",
+    optionalDescription: "Optional description",
+    create: "Create",
+    update: "Update",
+    clothing: "Clothing",
+    service: "Service",
+    category: "Category",
+    clothingCategories: "Clothing Categories",
+    serviceCategories: "Service Categories",
+    categoriesForClothingItems: "Categories for clothing items",
+    categoriesForLaundryServices: "Categories for laundry services",
+    active: "Active",
+    inactive: "Inactive",
+    noClothingCategoriesFound: "No clothing categories found",
+    noServiceCategoriesFound: "No service categories found",
+    pants: "Pants",
+    shirts: "Shirts",
+    traditional: "Traditional",
+    dresses: "Dresses",
+    formal: "Formal",
+    linens: "Linens",
+    clothingItemCreated: "Clothing item created successfully",
+    clothingItemUpdated: "Clothing item updated successfully",
+    clothingItemDeleted: "Clothing item deleted successfully",
+    serviceCreated: "Service created successfully",
+    serviceUpdated: "Service updated successfully",
+    serviceDeleted: "Service deleted successfully",
   },
   ar: {
     // Common
@@ -508,6 +612,58 @@ export const translations: Record<Language, Translations> = {
     welcome: "مرحباً بك في نظام إدارة الغسيل",
     loginFailed: "فشل تسجيل الدخول",
     missingCredentials: "يرجى إدخال اسم المستخدم وكلمة المرور",
+    logoutSuccess: "تم تسجيل الخروج بنجاح",
+    logoutFailed: "فشل تسجيل الخروج",
+    mainStore: "المتجر الرئيسي",
+    laundryManagementSystem: "نظام إدارة المغسلة",
+    allItems: "جميع العناصر",
+    loadingCategories: "جاري تحميل الفئات...",
+    failedToLoadCategories: "فشل تحميل الفئات",
+    loadingProducts: "جاري تحميل المنتجات...",
+    loadingClothingItems: "جاري تحميل عناصر الملابس...",
+    searchProducts: "بحث عن المنتجات...",
+    searchItemsServices: "البحث عن العناصر والخدمات...",
+    noProductsFound: "لم يتم العثور على منتجات",
+    stock: "المخزون",
+    searchClothingItems: "البحث عن عناصر الملابس...",
+    noClothingItemsFound: "لم يتم العثور على عناصر الملابس",
+    servicePriceInfo: "ستظهر أسعار الخدمات في الخطوة التالية",
+    categoryManagement: "إدارة الفئات",
+    inventoryManagement: "إدارة المخزون",
+    categoryCreated: "تم إنشاء الفئة بنجاح",
+    categoryUpdated: "تم تحديث الفئة بنجاح",
+    categoryDeleted: "تم حذف الفئة بنجاح",
+    errorCreatingCategory: "خطأ في إنشاء الفئة",
+    errorUpdatingCategory: "خطأ في تحديث الفئة",
+    errorDeletingCategory: "خطأ في حذف الفئة",
+    type: "النوع",
+    description: "الوصف",
+    optionalDescription: "وصف اختياري",
+    create: "إنشاء",
+    update: "تحديث",
+    clothing: "ملابس",
+    service: "خدمة",
+    category: "فئة",
+    clothingCategories: "فئات الملابس",
+    serviceCategories: "فئات الخدمات",
+    categoriesForClothingItems: "فئات لعناصر الملابس",
+    categoriesForLaundryServices: "فئات لخدمات الغسيل",
+    active: "نشط",
+    inactive: "غير نشط",
+    noClothingCategoriesFound: "لم يتم العثور على فئات ملابس",
+    noServiceCategoriesFound: "لم يتم العثور على فئات خدمات",
+    pants: "بنطال",
+    shirts: "قمصان",
+    traditional: "تقليدي",
+    dresses: "فساتين",
+    formal: "رسمي",
+    linens: "أقمشة",
+    clothingItemCreated: "تم إنشاء عنصر الملابس بنجاح",
+    clothingItemUpdated: "تم تحديث عنصر الملابس بنجاح",
+    clothingItemDeleted: "تم حذف عنصر الملابس بنجاح",
+    serviceCreated: "تم إنشاء الخدمة بنجاح",
+    serviceUpdated: "تم تحديث الخدمة بنجاح",
+    serviceDeleted: "تم حذف الخدمة بنجاح",
   },
   ur: {
     // Common
@@ -676,6 +832,58 @@ export const translations: Record<Language, Translations> = {
     welcome: "لانڈری مینجمنٹ سسٹم میں خوش آمدید",
     loginFailed: "لاگ اِن ناکام",
     missingCredentials: "براہ کرم صارف نام اور پاس ورڈ درج کریں",
+    logoutSuccess: "لاگ آؤٹ کامیاب رہا",
+    logoutFailed: "لاگ آؤٹ ناکام ہوا",
+    mainStore: "مین اسٹور",
+    laundryManagementSystem: "لانڈری مینجمنٹ سسٹم",
+    allItems: "تمام اشیاء",
+    loadingCategories: "زمرے لوڈ ہو رہے ہیں...",
+    failedToLoadCategories: "زمرے لوڈ کرنے میں ناکام",
+    loadingProducts: "مصنوعات لوڈ ہو رہی ہیں...",
+    loadingClothingItems: "کپڑوں کی اشیاء لوڈ ہو رہی ہیں...",
+    searchProducts: "مصنوعات تلاش کریں...",
+    searchItemsServices: "اشیاء اور خدمات تلاش کریں...",
+    noProductsFound: "کوئی مصنوعات نہیں ملی",
+    stock: "اسٹاک",
+    searchClothingItems: "کپڑوں کی اشیاء تلاش کریں...",
+    noClothingItemsFound: "کوئی کپڑوں کی اشیاء نہیں ملیں",
+    servicePriceInfo: "خدمات کی قیمتیں اگلے مرحلے میں دکھائی جائیں گی",
+    categoryManagement: "زمرہ جات کا انتظام",
+    inventoryManagement: "انوینٹری کا انتظام",
+    categoryCreated: "زمرہ کامیابی سے بن گیا",
+    categoryUpdated: "زمرہ کامیابی سے اپ ڈیٹ ہو گیا",
+    categoryDeleted: "زمرہ کامیابی سے حذف ہو گیا",
+    errorCreatingCategory: "زمرہ بنانے میں خرابی",
+    errorUpdatingCategory: "زمرہ اپ ڈیٹ کرنے میں خرابی",
+    errorDeletingCategory: "زمرہ حذف کرنے میں خرابی",
+    type: "قسم",
+    description: "تفصیل",
+    optionalDescription: "اختیاری تفصیل",
+    create: "بنائیں",
+    update: "اپ ڈیٹ",
+    clothing: "کپڑے",
+    service: "سروس",
+    category: "زمرہ",
+    clothingCategories: "کپڑوں کے زمرے",
+    serviceCategories: "سروس کے زمرے",
+    categoriesForClothingItems: "کپڑوں کی اشیاء کے لئے زمرے",
+    categoriesForLaundryServices: "لانڈری خدمات کے لئے زمرے",
+    active: "فعال",
+    inactive: "غیرفعال",
+    noClothingCategoriesFound: "کوئی کپڑوں کے زمرے نہیں ملے",
+    noServiceCategoriesFound: "کوئی سروس کے زمرے نہیں ملے",
+    pants: "پتلون",
+    shirts: "قمیضیں",
+    traditional: "روایتی",
+    dresses: "ڈریس",
+    formal: "فارمل",
+    linens: "لینن",
+    clothingItemCreated: "کپڑے کی چیز کامیابی سے بن گئی",
+    clothingItemUpdated: "کپڑے کی چیز کامیابی سے اپ ڈیٹ ہو گئی",
+    clothingItemDeleted: "کپڑے کی چیز کامیابی سے حذف ہو گئی",
+    serviceCreated: "سروس کامیابی سے بن گئی",
+    serviceUpdated: "سروس کامیابی سے اپ ڈیٹ ہو گئی",
+    serviceDeleted: "سروس کامیابی سے حذف ہو گئی",
   }
 };
 


### PR DESCRIPTION
## Summary
- localize POS header and product grid text using shared translations
- wire clothing and category management components to translation resources
- expand i18n dictionaries with common POS and admin phrases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f40c3425883238a7fc89a4e2ad2fb