### PR TITLE
feat: support optional laundry item price

### DIFF
--- a/client/src/hooks/use-laundry-cart.tsx
+++ b/client/src/hooks/use-laundry-cart.tsx
@@ -1,12 +1,17 @@
 import { useState, useCallback } from "react";
-import type { LaundryCartItem, LaundryCartSummary, ClothingItem, LaundryService } from "@shared/schema";
+import type {
+  LaundryCartItem,
+  LaundryCartSummary,
+  ClothingItem,
+  LaundryServiceWithItemPrice,
+} from "@shared/schema";
 import { getTaxRate } from "@/lib/tax";
 
 export function useLaundryCart() {
   const [cartItems, setCartItems] = useState<LaundryCartItem[]>([]);
   const [paymentMethod, setPaymentMethod] = useState<"cash" | "card" | "pay_later">("cash");
 
-  const addToCart = useCallback((clothingItem: ClothingItem, service: LaundryService & { itemPrice?: string }, quantity: number = 1) => {
+  const addToCart = useCallback((clothingItem: ClothingItem, service: LaundryServiceWithItemPrice, quantity: number = 1) => {
     setCartItems(prev => {
       // Create unique ID combining clothing item and service
       const uniqueId = `${clothingItem.id}-${service.id}`;
@@ -44,7 +49,11 @@ export function useLaundryCart() {
     setCartItems(prev =>
       prev.map(item =>
         item.id === id
-          ? { ...item, quantity, total: quantity * parseFloat((item.service as any).itemPrice ?? item.service.price) }
+          ? {
+              ...item,
+              quantity,
+              total: quantity * parseFloat(item.service.itemPrice ?? item.service.price),
+            }
           : item
       )
     );

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -365,6 +365,7 @@ export type UpsertUser = typeof users.$inferInsert;
 export type ClothingItem = typeof clothingItems.$inferSelect;
 export type InsertClothingItem = z.infer<typeof insertClothingItemSchema>;
 export type LaundryService = typeof laundryServices.$inferSelect;
+export type LaundryServiceWithItemPrice = LaundryService & { itemPrice?: string };
 export type InsertLaundryService = z.infer<typeof insertLaundryServiceSchema>;
 export type ItemServicePrice = typeof itemServicePrices.$inferSelect;
 export type InsertItemServicePrice = z.infer<typeof insertItemServicePriceSchema>;
@@ -408,7 +409,7 @@ export type BulkUploadResult = z.infer<typeof bulkUploadResultSchema>;
 export interface LaundryCartItem {
   id: string;
   clothingItem: ClothingItem;
-  service: LaundryService;
+  service: LaundryServiceWithItemPrice;
   quantity: number;
   total: number;
 }


### PR DESCRIPTION
## Summary
- extend laundry service type with optional item price
- allow cart quantity updates to use typed itemPrice

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689f45193c708323a8598713eef2b654