### PR TITLE
feat(pos): add delivery orders view

### DIFF
--- a/client/src/components/pos-sidebar.tsx
+++ b/client/src/components/pos-sidebar.tsx
@@ -12,6 +12,7 @@ export function POSSidebar({ activeView, onViewChange }: POSSidebarProps) {
     { id: "customers", label: "Customers", icon: Users },
     { id: "orders", label: "Orders", icon: Truck },
     { id: "reports", label: "Reports", icon: TrendingUp },
+    { id: "delivery-orders", label: "Delivery Orders", icon: Truck },
     { id: "inventory", label: "Inventory", icon: Package },
     { id: "settings", label: "Settings", icon: Settings }
   ];

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -12,6 +12,7 @@ import { SettingsPanel } from "@/components/settings-panel";
 import { CustomerManagement } from "@/components/customer-management";
 import { OrderTracking } from "@/components/order-tracking";
 import { BusinessReports } from "@/components/business-reports";
+import DispatcherDashboard from "@/components/delivery/DispatcherDashboard";
 import { useLaundryCart } from "@/hooks/use-laundry-cart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
@@ -200,12 +201,13 @@ export default function POS() {
       { id: "customers", label: "Customers", icon: Users },
       { id: "orders", label: "Orders", icon: Truck },
       { id: "reports", label: "Reports", icon: TrendingUp },
+      { id: "delivery-orders", label: "Delivery Orders", icon: Truck },
       { id: "settings", label: "Settings", icon: Settings }
     ];
 
     return (
       <nav className="fixed bottom-0 left-0 right-0 bg-pos-surface border-t border-gray-200 shadow-material-lg z-40">
-        <div className="grid grid-cols-5 h-16">
+        <div className="grid grid-cols-6 h-16">
           {navItems.map((item) => {
             const Icon = item.icon;
             const isActive = activeView === item.id;
@@ -267,6 +269,8 @@ export default function POS() {
         return <OrderTracking />;
       case "reports":
         return <BusinessReports />;
+      case "delivery-orders":
+        return <DispatcherDashboard />;
       case "inventory":
         return <InventoryManagement />;
       case "settings":


### PR DESCRIPTION
## Summary
- add Delivery Orders navigation item in sidebar and mobile nav
- render Delivery Orders with DispatcherDashboard

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689f53e0eb20832387076749fe16710d