### PR TITLE
feat: allow public product lookup by branch code

### DIFF
--- a/client/src/components/product-grid.tsx
+++ b/client/src/components/product-grid.tsx
@@ -66,7 +66,8 @@ export function ProductGrid({ onAddToCart, cartItemCount, onToggleCart, branchCo
       if (selectedCategory !== "all") params.append("categoryId", selectedCategory);
       if (searchQuery) params.append("search", searchQuery);
 
-      const response = await fetch(`/api/products?${params}`, {
+      const query = params.toString();
+      const response = await fetch(`/api/products${query ? `?${query}` : ""}`, {
         credentials: "include",
       });
       if (!response.ok) throw new Error("Failed to fetch products");


### PR DESCRIPTION
## Summary
- allow `/api/products` to fetch by `branchCode` without auth while preserving authenticated behavior
- ensure `ProductGrid` builds product query strings only when parameters provided
- add server tests for anonymous `branchCode` requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb40bce3c8323b0fd98ebb4d8dee1