### PR TITLE
feat: hide delivery pending orders until finalized

### DIFF
--- a/server/delivery-order.test.ts
+++ b/server/delivery-order.test.ts
@@ -57,7 +57,7 @@ test('delivery order stores dropoff coordinates', async () => {
         tax: '0',
         total: '0',
         paymentMethod: 'cash',
-        status: 'received',
+        status: 'delivery_pending',
         estimatedPickup: data.pickupTime ? new Date(data.pickupTime) : null,
         notes: data.address,
         sellerName: 'online',


### PR DESCRIPTION
## Summary
- add delivery_pending order status for delivery orders
- hide delivery_pending orders from normal listings unless requested
- support delivery_pending in order-tracking UI

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689fc60fa38c8323af141550f1c0cafb