### PR TITLE
feat: add language selector to delivery form

### DIFF
--- a/client/src/components/language-selector.tsx
+++ b/client/src/components/language-selector.tsx
@@ -7,23 +7,28 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useTranslation, Language } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
 
 const languages: { code: Language; name: string; nativeName: string }[] = [
-  { code: 'en', name: 'English', nativeName: 'English' },
-  { code: 'ar', name: 'Arabic', nativeName: 'العربية' },
-  { code: 'ur', name: 'Urdu', nativeName: 'اردو' },
+  { code: "en", name: "English", nativeName: "English" },
+  { code: "ar", name: "Arabic", nativeName: "العربية" },
+  { code: "ur", name: "Urdu", nativeName: "اردو" },
 ];
 
-export function LanguageSelector() {
+interface LanguageSelectorProps {
+  className?: string;
+}
+
+export function LanguageSelector({ className }: LanguageSelectorProps) {
   const { language, setLanguage } = useTranslation();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-2">
+        <Button variant="ghost" size="sm" className={cn("gap-2", className)}>
           <Globe className="h-4 w-4" />
           <span className="hidden sm:inline">
-            {languages.find(lang => lang.code === language)?.nativeName}
+            {languages.find((lang) => lang.code === language)?.nativeName}
           </span>
         </Button>
       </DropdownMenuTrigger>
@@ -33,7 +38,7 @@ export function LanguageSelector() {
             key={lang.code}
             onClick={() => setLanguage(lang.code)}
             className={`cursor-pointer ${
-              language === lang.code ? 'bg-blue-50 font-medium' : ''
+              language === lang.code ? "bg-blue-50 font-medium" : ""
             }`}
           >
             <div className="flex flex-col items-start">

--- a/client/src/routes/delivery/branch/[branchCode].tsx
+++ b/client/src/routes/delivery/branch/[branchCode].tsx
@@ -22,6 +22,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { ProductGrid } from "@/components/product-grid";
+import { LanguageSelector } from "@/components/language-selector";
 import { useCart } from "@/hooks/use-cart";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -228,12 +229,17 @@ export default function DeliveryOrderForm({ params }: { params: { branchCode: st
   const cartSummary = getCartSummary();
 
   return (
-    <Tabs
-      value={mode}
-      onValueChange={(val) => setMode(val as typeof mode)}
-      className="max-w-xl mx-auto p-4"
-      dir={language === "ar" ? "rtl" : "ltr"}
-    >
+    <div className="relative" dir={language === "ar" ? "rtl" : "ltr"}>
+      <LanguageSelector
+        className={`absolute top-4 ${
+          language === "ar" ? "left-4" : "right-4"
+        }`}
+      />
+      <Tabs
+        value={mode}
+        onValueChange={(val) => setMode(val as typeof mode)}
+        className="max-w-xl mx-auto p-4"
+      >
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="choose" className="flex items-center gap-2">
           <List className="h-4 w-4" />
@@ -478,6 +484,7 @@ export default function DeliveryOrderForm({ params }: { params: { branchCode: st
           </Card>
         </form>
       </TabsContent>
-    </Tabs>
+      </Tabs>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow `LanguageSelector` to accept custom classes
- add language selector to delivery branch order form
- ensure form layout respects RTL languages

## Testing
- `npm test`
- `npm run check` *(fails: Type 'Set<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a99f4c9883238d80a2d0739027fe