### PR TITLE
feat: enhance delivery order confirmation

### DIFF
--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -273,13 +273,15 @@ export interface Translations {
   scheduleVisit: string;
   pickupTime: string;
   deliveryTime: string;
-  location: string;
+  locationLabel: string;
   useCurrentLocation: string;
   products: string;
   noItemsSelected: string;
   submitOrder: string;
   submitting: string;
   scheduling: string;
+  createAnotherOrder: string;
+  returnToBranchInfo: string;
 }
 
 export const translations: Record<Language, Translations> = {
@@ -561,6 +563,8 @@ export const translations: Record<Language, Translations> = {
     submitOrder: "Submit Order",
     submitting: "Submitting...",
     scheduling: "Scheduling...",
+    createAnotherOrder: "Create Another Order",
+    returnToBranchInfo: "Return to Branch Info",
   },
   ar: {
     // Common
@@ -840,6 +844,8 @@ export const translations: Record<Language, Translations> = {
     submitOrder: "إرسال الطلب",
     submitting: "جاري الإرسال...",
     scheduling: "جاري الجدولة...",
+    createAnotherOrder: "إنشاء طلب آخر",
+    returnToBranchInfo: "العودة إلى معلومات الفرع",
   },
   ur: {
     // Common
@@ -1119,6 +1125,8 @@ export const translations: Record<Language, Translations> = {
     submitOrder: "Submit Order",
     submitting: "Submitting...",
     scheduling: "Scheduling...",
+    createAnotherOrder: "Create Another Order",
+    returnToBranchInfo: "Return to Branch Info",
   }
 };
 

--- a/server/delivery-order.test.ts
+++ b/server/delivery-order.test.ts
@@ -19,7 +19,7 @@ test('delivery order stores dropoff coordinates', async () => {
   let inserted: any = null;
 
   storage.getBranchByCode = async () => ({ id: 'b1', code: 'ABC', address: null } as any);
-  storage.createOrder = async () => ({ id: 'o1' } as any);
+  storage.createOrder = async () => ({ id: 'o1', orderNumber: 'ABC-0001' } as any);
   (db as any).insert = () => ({
     values: async (vals: any) => {
       inserted = vals;
@@ -76,7 +76,7 @@ test('delivery order stores dropoff coordinates', async () => {
         distanceMeters: null,
         durationSeconds: null,
       });
-      res.status(201).json({ orderId: order.id });
+      res.status(201).json({ orderId: order.id, orderNumber: order.orderNumber });
     } catch (err) {
       res.status(400).json({ message: 'Invalid order data' });
     }
@@ -95,6 +95,7 @@ test('delivery order stores dropoff coordinates', async () => {
   assert.equal(res.status, 201);
   assert.equal(inserted.dropoffLat, 1.23);
   assert.equal(inserted.dropoffLng, 4.56);
+  assert.equal(res.body.orderNumber, 'ABC-0001');
 
   storage.getBranchByCode = origGetBranch;
   storage.createOrder = origCreateOrder;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -354,6 +354,19 @@ export async function registerRoutes(
     },
   );
 
+  // Public branch info
+  app.get("/api/branches/:code", async (req, res) => {
+    try {
+      const branch = await storage.getBranchByCode(req.params.code);
+      if (!branch) {
+        return res.status(404).json({ message: "Branch not found" });
+      }
+      res.json(branch);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch branch" });
+    }
+  });
+
   // Branch management routes (Super Admin only)
   app.get("/api/branches", requireSuperAdmin, async (_req, res) => {
     try {
@@ -1306,7 +1319,7 @@ export async function registerRoutes(
         }
       });
 
-      res.status(201).json({ orderId: order.id });
+      res.status(201).json({ orderId: order.id, orderNumber: order.orderNumber });
     } catch (error) {
       console.error("Error creating delivery order:", error);
       res.status(400).json({ message: "Invalid order data" });


### PR DESCRIPTION
## Summary
- expose public `/api/branches/:code` endpoint and return `orderNumber` from delivery orders
- show branch logo/name and order confirmation card in delivery form
- add translations for new confirmation actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b16feedc83239a82ec066c47c44c