### PR TITLE
feat: introduce translation context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider, useAuthContext } from "@/context/AuthContext";
+import { TranslationProvider } from "@/context/TranslationContext";
 import { LoginForm } from "@/components/auth/LoginForm";
 import NotFound from "@/pages/not-found";
 import POS from "@/pages/pos";
@@ -49,12 +50,14 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Router />
-        </TooltipProvider>
-      </AuthProvider>
+      <TranslationProvider>
+        <AuthProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Router />
+          </TooltipProvider>
+        </AuthProvider>
+      </TranslationProvider>
     </QueryClientProvider>
   );
 }

--- a/client/src/components/product-grid.test.tsx
+++ b/client/src/components/product-grid.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, vi, expect, afterEach } from "vitest";
 import { ProductGrid } from "./product-grid";
+import { TranslationProvider } from "@/context/TranslationContext";
 
 const matchMediaMock = vi.fn().mockReturnValue({
   matches: false,
@@ -23,7 +24,9 @@ function renderWithClient() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <ProductGrid onAddToCart={() => {}} cartItemCount={0} onToggleCart={() => {}} />
+      <TranslationProvider>
+        <ProductGrid onAddToCart={() => {}} cartItemCount={0} onToggleCart={() => {}} />
+      </TranslationProvider>
     </QueryClientProvider>,
   );
 }

--- a/client/src/context/TranslationContext.tsx
+++ b/client/src/context/TranslationContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
+import { translations, type Language, type Translations } from "@/lib/i18n";
+
+interface TranslationContextValue {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: Translations;
+}
+
+const TranslationContext = createContext<TranslationContextValue | undefined>(undefined);
+
+export function TranslationProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Language>(() => {
+    return (localStorage.getItem("language") as Language) || "en";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("language", language);
+    document.dir = language === "ar" || language === "ur" ? "rtl" : "ltr";
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const t = translations[language];
+
+  return (
+    <TranslationContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </TranslationContext.Provider>
+  );
+}
+
+export function useTranslationContext() {
+  const context = useContext(TranslationContext);
+  if (!context) {
+    throw new Error("useTranslation must be used within a TranslationProvider");
+  }
+  return context;
+}
+
+export { TranslationContext };
+

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useContext } from "react";
+import { TranslationContext } from "@/context/TranslationContext";
 
 export type Language = 'en' | 'ar' | 'ur';
 
@@ -112,6 +113,7 @@ export interface Translations {
   // Company Info
   companyName: string;
   companyTagline: string;
+  location: string;
   locationLabel: string;
   phone: string;
 
@@ -273,7 +275,6 @@ export interface Translations {
   scheduleVisit: string;
   pickupTime: string;
   deliveryTime: string;
-  locationLabel: string;
   useCurrentLocation: string;
   products: string;
   noItemsSelected: string;
@@ -1131,19 +1132,11 @@ export const translations: Record<Language, Translations> = {
 };
 
 export const useTranslation = () => {
-  const [language, setLanguage] = useState<Language>(() => {
-    return (localStorage.getItem('language') as Language) || 'en';
-  });
-
-  useEffect(() => {
-    localStorage.setItem('language', language);
-    document.dir = language === 'ar' || language === 'ur' ? 'rtl' : 'ltr';
-    document.documentElement.lang = language;
-  }, [language]);
-
-  const t = translations[language];
-
-  return { t, language, setLanguage };
+  const context = useContext(TranslationContext);
+  if (!context) {
+    throw new Error("useTranslation must be used within a TranslationProvider");
+  }
+  return context;
 };
 
 // Remove this function as we now use the currency system

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -510,9 +510,9 @@ export async function registerRoutes(
           return res.status(404).json({ message: "Branch not found" });
         }
         const productsList = await storage.getProducts(branch.id);
-        const categoryIds = [
-          ...new Set(productsList.map(p => p.categoryId).filter((id): id is string => Boolean(id))),
-        ];
+        const categoryIds = Array.from(
+          new Set(productsList.map(p => p.categoryId).filter((id): id is string => Boolean(id)))
+        );
         if (categoryIds.length === 0) {
           return res.json([]);
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
     "module": "ESNext",
+    "target": "ES2020",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- add TranslationContext provider to manage language state and translations
- refactor i18n hook to read from context and wrap App in provider
- adjust tests and build settings to support new translation context

## Testing
- `npm test`
- `npm run check` *(fails: Type 'Set<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.)*


------
https://chatgpt.com/codex/tasks/task_e_68a0b30fdec8832394b4593f35bcd80a